### PR TITLE
implement upload2 command and defectdojo client module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ terraform.rc
 
 #
 .terraform.lock.hcl
+
+# 
+__debug_bin

--- a/cmd/upload2.go
+++ b/cmd/upload2.go
@@ -1,0 +1,77 @@
+/*
+Copyright © 2022 NAME HERE <EMAIL ADDRESS>
+*/
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/scan-io-git/scan-io/internal/dojo"
+
+	"github.com/spf13/cobra"
+)
+
+var DOJO_TOKEN = os.Getenv("DEFECTDOJO_TOKEN")
+
+type UploadOptions struct {
+	URL         string
+	InputFile   string
+	ProductName string
+	ScanType    string
+}
+
+var allUploadOptions UploadOptions
+
+// upload2Cmd represents the upload command
+var uploadCmd = &cobra.Command{
+	Use:   "upload2",
+	Short: "[EXPERIMENTAL] Upload results to defectdojo",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Println("uploadCmd called")
+		fmt.Printf("DefectDojo URL: %s\n", allUploadOptions.URL)
+
+		dojoClient := dojo.New(allUploadOptions.URL, DOJO_TOKEN)
+
+		exists, err := dojoClient.IsAnySLAConfiguration()
+		if err != nil {
+			return err
+		}
+
+		if !exists {
+			if _, err := dojoClient.CreateSLAConfiguration(dojo.GetDefaultSLAConfigurationParams()); err != nil {
+				return err
+			}
+		}
+
+		productType, err := dojoClient.GetOrCreateProductType(dojo.ProductTypeScanioRepo)
+		if err != nil {
+			return err
+		}
+
+		product, err := dojoClient.GetOrCreateProduct(allUploadOptions.ProductName, *productType)
+		if err != nil {
+			return err
+		}
+
+		engagement, err := dojoClient.CreateEngagement(*product)
+		if err != nil {
+			return err
+		}
+
+		if err = dojoClient.ImportScanResult(*engagement, allUploadOptions.InputFile, allUploadOptions.ScanType); err != nil {
+			return err
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(uploadCmd)
+
+	uploadCmd.Flags().StringVarP(&allUploadOptions.URL, "url", "u", "http://defectdojo.example.com:8080", "DefectDojo URL")
+	uploadCmd.Flags().StringVarP(&allUploadOptions.InputFile, "input", "f", "", "report filepath")
+	uploadCmd.Flags().StringVarP(&allUploadOptions.ProductName, "product", "p", "", "product name")
+	uploadCmd.Flags().StringVarP(&allUploadOptions.ScanType, "scan-type", "t", "", "scan type")
+}

--- a/cmd/uploadResults.go
+++ b/cmd/uploadResults.go
@@ -201,7 +201,7 @@ func uploadResultsToDefectDojo(reposDetails []shared.RepositoryParams) error {
 // uploadResultsCmd represents the uploadResults command
 var uploadResultsCmd = &cobra.Command{
 	Use:   "upload-results",
-	Short: "[EXPERIMENTAL] Upload results to defectdojo",
+	Short: "[DEPRICATED] Upload results to defectdojo",
 	// Long: `A longer description that spans multiple lines and likely contains examples
 	// and usage of using your command. For example:
 

--- a/docs/upload2.md
+++ b/docs/upload2.md
@@ -1,0 +1,10 @@
+Upload2 is a generic command for upload scan results to defectdojo.  
+Upload2 automatically create sla configuration is there are no any sla configurations.
+Upload2 create new product type, specially dedicated for scanio results.
+Upload2 creates product if it does not exist.
+
+
+Usage example:
+```
+scanio upload2 -u https://defectdojo.example.com -p github.com/juice-shop/juice-shop -f ~/.scanio/results/github.com/juice-shop/juice-shop/semgrep-2023-05-13T11:09:04Z.json -t "Semgrep JSON Report"
+```

--- a/internal/dojo/client.go
+++ b/internal/dojo/client.go
@@ -1,0 +1,298 @@
+package dojo
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-resty/resty/v2"
+)
+
+const (
+	ProductTypeScanioRepo = "SCANIO-REPO"
+)
+
+type Client struct {
+	httpc *resty.Client
+	url   string
+}
+
+func New(url string, token string) Client {
+	httpc := resty.New()
+	httpc.SetBaseURL(url)
+	httpc.SetHeader("Authorization", fmt.Sprintf("Token %s", token))
+
+	return Client{
+		httpc: httpc,
+		url:   url,
+	}
+}
+
+type ProductType struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+type GetProductTypesResult struct {
+	Count   int           `json:"count"`
+	Results []ProductType `json:"results"`
+}
+
+type Product struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+type GetProductsResult struct {
+	Count   int       `json:"count"`
+	Results []Product `json:"results"`
+}
+
+type Engagement struct {
+	ID        int `json:"id"`
+	ProductID int `json:"product"`
+}
+
+type SLAConfiguration struct {
+	ID          int    `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Critical    int    `json:"critical"`
+	High        int    `json:"high"`
+	Medium      int    `json:"medium"`
+	Low         int    `json:"low"`
+}
+
+func GetDefaultSLAConfigurationParams() SLAConfiguration {
+	return SLAConfiguration{
+		Name:        "SCANIO-SLA-CONFIGURATION",
+		Description: "Default scanio sla configuration",
+		Critical:    7,
+		High:        30,
+		Medium:      90,
+		Low:         120,
+	}
+}
+
+type GetSLAConfigurationResult struct {
+	Count   int                `json:"count"`
+	Results []SLAConfiguration `json:"results"`
+}
+
+func (c Client) IsAnySLAConfiguration() (bool, error) {
+	var r GetSLAConfigurationResult
+	resp, err := c.httpc.R().
+		SetResult(&r).
+		Get("/api/v2/sla_configurations/")
+	if err != nil {
+		return false, err
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return false, fmt.Errorf("%d on getting sla_configurations", resp.StatusCode())
+	}
+	return r.Count > 0, nil
+}
+
+func (c Client) GetSLAConfiguration(name string) (*SLAConfiguration, error) {
+	var r GetSLAConfigurationResult
+	resp, err := c.httpc.R().
+		SetResult(&r).
+		Get("/api/v2/sla_configurations/")
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return nil, fmt.Errorf("%d on getting sla_configurations '%s'", resp.StatusCode(), name)
+	}
+
+	for _, sla := range r.Results {
+		if sla.Name == name {
+			return &sla, nil
+		}
+	}
+	return nil, fmt.Errorf("sla_configurations with name '%s' was not found", name)
+}
+
+func (c Client) CreateSLAConfiguration(sla SLAConfiguration) (*SLAConfiguration, error) {
+	var createdSLA SLAConfiguration
+	resp, err := c.httpc.R().
+		SetBody(map[string]interface{}{
+			"name":        sla.Name,
+			"description": sla.Description,
+			"critical":    sla.Critical,
+			"high":        sla.High,
+			"medium":      sla.Medium,
+			"low":         sla.Low,
+		}).
+		SetResult(&createdSLA).
+		Post("/api/v2/sla_configuration/")
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode() != http.StatusCreated {
+		return nil, fmt.Errorf("response != 201 on creating sla configuration '%s'", sla.Name)
+	}
+	return &createdSLA, nil
+}
+
+func (c Client) GetOrCreateSLAConfiguration(config SLAConfiguration) (*SLAConfiguration, error) {
+	sla, err := c.GetSLAConfiguration(config.Name)
+	if err != nil {
+		return nil, err
+	}
+	if sla != nil {
+		return sla, nil
+	}
+	return c.CreateSLAConfiguration(config)
+}
+
+func (c Client) GetOrCreateDefaultSLAConfiguration() (*SLAConfiguration, error) {
+	return c.GetOrCreateSLAConfiguration(GetDefaultSLAConfigurationParams())
+}
+
+func (c Client) GetProductType(productTypeName string) (*ProductType, error) {
+	var r GetProductTypesResult
+	resp, err := c.httpc.R().
+		SetQueryParams(map[string]string{
+			"name": productTypeName,
+		}).
+		SetResult(&r).
+		Get("/api/v2/product_types/")
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return nil, fmt.Errorf("%d on getting product_types '%s'", resp.StatusCode(), productTypeName)
+	}
+	if r.Count > 1 {
+		return nil, fmt.Errorf("multiple product_types with the same name '%s'", productTypeName)
+	}
+	if r.Count == 0 {
+		return nil, nil
+	}
+	return &r.Results[0], nil
+}
+
+func (c Client) CreateProductType(productTypeName string) (*ProductType, error) {
+	var p ProductType
+	resp, err := c.httpc.R().
+		SetFormData(map[string]string{
+			"name": productTypeName,
+		}).
+		SetResult(&p).
+		Post("/api/v2/product_types/")
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode() != http.StatusCreated {
+		return nil, fmt.Errorf("%d on getting product '%s'", resp.StatusCode(), productTypeName)
+	}
+	return &p, nil
+}
+
+func (c Client) GetOrCreateProductType(productTypeName string) (*ProductType, error) {
+	productType, err := c.GetProductType(productTypeName)
+	if err != nil {
+		return nil, err
+	}
+	if productType != nil {
+		return productType, nil
+	}
+	return c.CreateProductType(productTypeName)
+}
+
+func (c Client) GetProduct(productName string) (*Product, error) {
+	var r GetProductsResult
+	resp, err := c.httpc.R().
+		SetQueryParams(map[string]string{
+			"name": productName,
+		}).
+		SetResult(&r).
+		Get("/api/v2/products/")
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return nil, fmt.Errorf("%d on getting product '%s'", resp.StatusCode(), productName)
+	}
+	if r.Count > 1 {
+		return nil, fmt.Errorf("multiple products with the same name '%s'", productName)
+	}
+	if r.Count == 0 {
+		return nil, nil
+	}
+	return &r.Results[0], nil
+}
+
+func (c Client) CreateProduct(productName string, productType ProductType) (*Product, error) {
+	var p Product
+	resp, err := c.httpc.R().
+		SetFormData(map[string]string{
+			"name":        productName,
+			"description": fmt.Sprintf("Default desctiption for product: '%s'", productName),
+			"prod_type":   strconv.Itoa(productType.ID),
+		}).
+		SetResult(&p).
+		Post("/api/v2/products/")
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode() != http.StatusCreated {
+		return nil, fmt.Errorf("%d on creating product '%s'", resp.StatusCode(), productName)
+	}
+	return &p, nil
+}
+
+func (c Client) GetOrCreateProduct(productName string, productType ProductType) (*Product, error) {
+	product, err := c.GetProduct(productName)
+	if err != nil {
+		return nil, err
+	}
+	if product != nil {
+		return product, nil
+	}
+	return c.CreateProduct(productName, productType)
+}
+
+func (c Client) CreateEngagement(product Product) (*Engagement, error) {
+	var engagement Engagement
+	currentDate := time.Now().Format("2006-01-02")
+	resp, err := c.httpc.R().
+		SetFormData(map[string]string{
+			"target_start": currentDate,
+			"target_end":   currentDate,
+			"status":       "Completed",
+			"product":      strconv.Itoa(product.ID),
+			"name":         "scan-io",
+		}).
+		SetResult(&engagement).
+		Post("/api/v2/engagements/")
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode() != http.StatusCreated {
+		return nil, fmt.Errorf("%d on creating engagement for product '%s'", resp.StatusCode(), product.Name)
+	}
+	return &engagement, nil
+}
+
+func (c Client) ImportScanResult(engagement Engagement, resultPath string, scanType string) error {
+	resp, err := c.httpc.R().
+		SetFiles(map[string]string{
+			"file": resultPath,
+		}).
+		SetFormData(map[string]string{
+			"engagement": strconv.Itoa(engagement.ID),
+			"scan_type":  scanType, // "SARIF",
+			// "service":    repo.RepoName,
+		}).
+		Post("/api/v2/import-scan/")
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode() != http.StatusCreated {
+		return fmt.Errorf("%d on importing results to engagement '%d'", resp.StatusCode(), engagement.ID)
+	}
+	return nil
+}


### PR DESCRIPTION
* Rewrote import of results in defectdojo. New command `upload2` was implemented for this. Previous command `upload-results` didn't have enough flexibility, because of hardcoded filenames, and therefore was deprecated.
* Moved defectdojo client code into a separate module.
* Fixed a couple of bugs, such as when there is no SLA Configuration in DefectDojo, then create it and some other things.