### PR TITLE
add tool-specific folder in /rules

### DIFF
--- a/docs/prep_semgrep_rules.md
+++ b/docs/prep_semgrep_rules.md
@@ -1,6 +1,6 @@
 # Rules preparation script 
 `scripts/prep_semgrep_rules.sh` is a script that prepares semgrep rules, by fetching remote repositories and copying rules into the `/rules` folder. This could be used for preparing a list of verified rules to put into a docker container. A common scenario is when you prepare a list of rules, which provide good findings, which you want to show to developers.  
-After building a docker image, one can use `scanio analyse --scanner semgrep -c /scanio-rules /path/to/project` or natively `semgrep -c /scanio-rules`.<br><br>
+After building a docker image, one can use `scanio analyse --scanner semgrep -c /scanio-rules/semgrep /path/to/project` or natively `semgrep -c /scanio-rules/semgrep`.<br><br>
 
 ## Examples
 **Default mode**<br>
@@ -16,10 +16,10 @@ The script will download rules from a repo - https://github.com/trailofbits/semg
 
 **Mergin mode**<br>
 The command merges rules from a specified directory to a "semgrep-rules" folder.<br>
-```./prep_semgrep_rules.sh -m /scan-io/rules/returntocorp```<br>
+```./prep_semgrep_rules.sh -m /scan-io/rules/semgrep/returntocorp```<br>
 The script will copy all rules to a "semgrep-rules" folder and delete the "returntocorp" folder.<br><br>
 
-```./prep_semgrep_rules.sh -m /scan-io/rules/trailofbits```<br>
+```./prep_semgrep_rules.sh -m /scan-io/rules/semgrep/trailofbits```<br>
 The script will copy all rules to a "semgrep-rules" folder and delete the "trailofbits" folder.<br><br>
 
 **Auto mode**<br>

--- a/scripts/prep_semgrep_rules.sh
+++ b/scripts/prep_semgrep_rules.sh
@@ -153,7 +153,7 @@ handle_repo() {
 init_for_rules() {
     SCRIPT_DIR=$( dirname -- "$( readlink -f -- "$0"; )"; )
     PARENT_DIR=$( dirname -- $SCRIPT_DIR )
-    RULES_DIR="$PARENT_DIR/rules/$BASE_FOLDER"
+    RULES_DIR="$PARENT_DIR/rules/semgrep/$BASE_FOLDER"
     echo "Rules directory to safe files - $RULES_DIR"
 }
 


### PR DESCRIPTION
This MR propose better structure for /rules folder. Now it also has one more folder level per tool.

Structure before:
```
rules/
└── returntocorp
└── trailofbits
```
New structure:
```
rules/
└── semgrep
    └── returntocorp
    └── trailofbits
```

This change will allow to have tool breakdown in rules folder. For example one can store trufflehog3 or any other rules in same /rules folder, which acts as main folder for custom rules inside a docker container. And it also makes easy specifying config for individual tools, like: `scanio analyse --scanner semgrep -c /scanio-rules/semgrep`, instead of specifying multiple configs or making multiple runs.