### PR TITLE
build and push docker image for releases

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -7,11 +7,13 @@
 # To get a newer version, you will need to update the SHA.
 # You can also reference a tag or branch, but the action may change without warning.
 
-name: Create and publish a Docker image
+name: Create and publish a Docker image for main branch and published releases
 
 on:
   push:
     branches: ['main']
+  release:
+    types: [published]
 
 env:
   REGISTRY: ghcr.io
@@ -35,11 +37,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # - name: Extract metadata (tags, labels) for Docker
-      #   id: meta
-      #   uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
-      #   with:
-      #     images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       
       - name: Prepare semgrep rules
         run: cd scripts && ./prep_semgrep_rules.sh -r rules_semgrep.txt https://github.com/returntocorp/semgrep-rules.git release
@@ -49,6 +51,6 @@ jobs:
         with:
           context: .
           push: true
-          tags: ghcr.io/scan-io-git/scan-io:latest
-          # tags: ${{ steps.meta.outputs.tags }}
-          # labels: ${{ steps.meta.outputs.labels }}
+          # tags: ghcr.io/scan-io-git/scan-io:latest
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
With this MR docker build workflow will be triggered on release events: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release.

I expect "docker/metadata-action" action will take care of correct tags: https://github.com/docker/metadata-action.
