### PR TITLE
New features in CI mod and integration cmd with refactoring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,14 +97,11 @@ RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/s
     rm -rf get_helm.sh
 
 # Set environment variables // move to config file
-ENV SCANIO_HOME=/data
-ENV SCANIO_PLUGINS_FOLDER=/scanio-plugins
 ENV JOB_HELM_CHART_PATH=/scanio-helm/scanio-job
 
 # Create necessary directories
 RUN mkdir -p /scanio
 RUN mkdir -p /data
-RUN mkdir -p /scanio/scanio-plugins
 
 # Copy built binaries and other necessary files from the build stage
 COPY --from=build-scanio /usr/bin/scanio /bin/scanio

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -119,7 +119,7 @@ func scan(repo string) {
 
 	shared.WithPlugin(AppConfig, "plugin-scanner", shared.PluginTypeScanner, o.ScannerPlugin, func(raw interface{}) error {
 		raw.(shared.Scanner).Scan(shared.ScannerScanRequest{
-			RepoPath:    repoPath,
+			TargetPath:  repoPath,
 			ResultsPath: getResultsPath(logger, repo),
 		})
 		return nil

--- a/cmd/run2.go
+++ b/cmd/run2.go
@@ -44,9 +44,9 @@ var allRun2Options Run2Options
 func run2analyzeRepos(repos []shared.RepositoryParams) error {
 
 	logger := logger.NewLogger(AppConfig, "core-run2-scanner")
-	s := scanner.New(allRun2Options.ScannerPluginName, allRun2Options.Jobs, allRun2Options.Config, allRun2Options.ReportFormat, allRun2Options.AdditionalArgs, logger)
+	s := scanner.New(allRun2Options.ScannerPluginName, allRun2Options.Config, allRun2Options.ReportFormat, allRun2Options.AdditionalArgs, allRun2Options.Jobs, logger)
 
-	scanArgs, err := s.PrepScanArgs(AppConfig, repos, "", "")
+	scanArgs, err := s.PrepareScanArgs(AppConfig, repos, "", "")
 	if err != nil {
 		return err
 	}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -7,96 +7,150 @@ import (
 	"strings"
 	"time"
 
-	utils "github.com/scan-io-git/scan-io/internal/utils"
-
 	"github.com/hashicorp/go-hclog"
 	"github.com/scan-io-git/scan-io/pkg/shared"
 	"github.com/scan-io-git/scan-io/pkg/shared/config"
+	"github.com/scan-io-git/scan-io/pkg/shared/files"
+
+	utils "github.com/scan-io-git/scan-io/internal/utils"
 )
 
+// Scanner represents the basic configuration and behavior of a scanner.
 type Scanner struct {
-	additionalArgs    []string
-	config            string
-	scannerPluginName string
-	reportFormat      string
-	logger            hclog.Logger
-	jobs              int
+	pluginName     string       // Name of the scanner plugin to use
+	configPath     string       // Path to the configuration file for the scanner
+	reportFormat   string       // Format of the report to generate (e.g., JSON, Sarif)
+	additionalArgs []string     // Additional arguments for the scanner
+	concurrentJobs int          // Number of concurrent jobs to run
+	logger         hclog.Logger // Logger for logging messages and errors
 }
 
-func New(scannerPluginName string, jobs int, config string, reportFormat string, additionalArgs []string, logger hclog.Logger) Scanner {
-	return Scanner{
-		additionalArgs:    additionalArgs,
-		config:            config,
-		scannerPluginName: scannerPluginName,
-		reportFormat:      reportFormat,
-		logger:            logger,
-		jobs:              jobs,
+// New creates a new Scanner instance with the provided configuration.
+func New(pluginName, configPath, reportFormat string, additionalArgs []string, concurrentJobs int, logger hclog.Logger) *Scanner {
+	return &Scanner{
+		pluginName:     pluginName,
+		configPath:     configPath,
+		reportFormat:   reportFormat,
+		additionalArgs: additionalArgs,
+		concurrentJobs: concurrentJobs,
+		logger:         logger,
 	}
 }
 
-func (s Scanner) PrepScanArgs(cfg *config.Config, repos []shared.RepositoryParams, path, outputPrefix string) ([]shared.ScannerScanRequest, error) {
-	var (
-		scanArgs     []shared.ScannerScanRequest
-		targetFolder string
-		resultsPath  string
-		prefix       string
-	)
+// PrepareScanArgs prepares the arguments needed for the scan operation with the provided configuration.
+func (s *Scanner) PrepareScanArgs(cfg *config.Config, repos []shared.RepositoryParams, targetPath, outputPath string) ([]shared.ScannerScanRequest, error) {
+	var scanArgs []shared.ScannerScanRequest
 
-	// make dynamic extension name, based on output format
+	// Determine report extension based on the format
 	reportExt := "raw"
-	rawStartTime := time.Now().UTC()
-	startTime := rawStartTime.Format(time.RFC3339)
-	if len(s.reportFormat) > 0 {
+	if s.reportFormat != "" {
 		reportExt = s.reportFormat
 	}
 
-	if len(path) != 0 {
-		prefix = path
-		if outputPrefix != "" {
-			// in the case with a manual path the result will be written to the same folder
-			prefix = outputPrefix
+	// Determine the name template based on the CI mode
+	nameTemplate := s.generateNameTemplate(cfg, reportExt)
+
+	// Handle single target path scenario
+	if targetPath != "" {
+		resultsFile, err := s.determineResultsFilePath(targetPath, outputPath, nameTemplate)
+		if err != nil {
+			return nil, err
 		}
 
-		targetFolder = path
-		resultsPath = filepath.Join(prefix, fmt.Sprintf("%s-%s.%s", s.scannerPluginName, startTime, reportExt))
-
 		scanArgs = append(scanArgs, shared.ScannerScanRequest{
-			RepoPath:       targetFolder,
-			ResultsPath:    resultsPath,
-			ConfigPath:     s.config,
-			AdditionalArgs: s.additionalArgs,
+			TargetPath:     targetPath,
+			ResultsPath:    resultsFile,
+			ConfigPath:     s.configPath,
 			ReportFormat:   s.reportFormat,
+			AdditionalArgs: s.additionalArgs,
 		})
 	} else {
+		// Handle multiple repositories scenario
 		for _, repo := range repos {
-			domain, err := utils.GetDomain(repo.SshLink)
+			scanArg, err := s.prepareRepoScanArg(cfg, repo, nameTemplate)
 			if err != nil {
-				domain, err = utils.GetDomain(repo.HttpLink)
-				if err != nil {
-					return nil, err
-				}
-			}
-
-			resultsFolderPath := filepath.Join(config.GetScanioResultsHome(cfg), strings.ToLower(domain), filepath.Join(strings.ToLower(repo.Namespace), strings.ToLower(repo.RepoName)))
-			// ensure that folder for results exists, some scanners don't create it themselves and just exit with an error
-			if err := os.MkdirAll(resultsFolderPath, os.ModePerm); err != nil {
 				return nil, err
 			}
-
-			targetFolder = config.GetRepositoryPath(cfg, domain, filepath.Join(repo.Namespace, repo.RepoName))
-			resultsPath = filepath.Join(resultsFolderPath, fmt.Sprintf("%s-%s.%s", s.scannerPluginName, startTime, reportExt))
-
-			scanArgs = append(scanArgs, shared.ScannerScanRequest{
-				RepoPath:       targetFolder,
-				ResultsPath:    resultsPath,
-				ConfigPath:     s.config,
-				AdditionalArgs: s.additionalArgs,
-				ReportFormat:   s.reportFormat,
-			})
+			scanArgs = append(scanArgs, scanArg)
 		}
 	}
 
 	return scanArgs, nil
+}
+
+// prepareRepoScanArg prepares the scan arguments for a repository.
+func (s *Scanner) prepareRepoScanArg(cfg *config.Config, repo shared.RepositoryParams, nameTemplate string) (shared.ScannerScanRequest, error) {
+	domain, err := utils.GetDomain(repo.SshLink)
+	if err != nil {
+		domain, err = utils.GetDomain(repo.HttpLink)
+		if err != nil {
+			return shared.ScannerScanRequest{}, err
+		}
+	}
+
+	resultsFolderPath := filepath.Join(config.GetScanioResultsHome(cfg), strings.ToLower(domain), strings.ToLower(repo.Namespace), strings.ToLower(repo.RepoName))
+	targetPath := config.GetRepositoryPath(cfg, domain, filepath.Join(repo.Namespace, repo.RepoName))
+	resultsFile := filepath.Join(resultsFolderPath, nameTemplate)
+
+	if err := files.CreateFolderIfNotExists(resultsFolderPath); err != nil {
+		return shared.ScannerScanRequest{}, fmt.Errorf("failed to create results folder '%s': %w", resultsFolderPath, err)
+	}
+
+	return shared.ScannerScanRequest{
+		TargetPath:     targetPath,
+		ResultsPath:    resultsFile,
+		ConfigPath:     s.configPath,
+		ReportFormat:   s.reportFormat,
+		AdditionalArgs: s.additionalArgs,
+	}, nil
+}
+
+// determineResultsFilePath determines the results file path based on target and output paths.
+func (s *Scanner) determineResultsFilePath(targetPath, outputPath, nameTemplate string) (string, error) {
+	if outputPath != "" {
+		return s.handleOutputPath(outputPath, nameTemplate)
+	}
+	return s.handleOutputPath(targetPath, nameTemplate)
+}
+
+// handleOutputPath handles the output path, creating directories as necessary.
+func (s *Scanner) handleOutputPath(path, nameTemplate string) (string, error) {
+	var resultsFile, resultsFolder string
+
+	fileInfo, err := os.Stat(path)
+	if err == nil && fileInfo.IsDir() {
+		// It's a directory
+		resultsFolder = path
+		resultsFile = filepath.Join(path, nameTemplate)
+	} else {
+		// It's a file or doesn't exist
+		ext := filepath.Ext(path)
+		if ext == "" {
+			// No extension, treat as directory
+			resultsFolder = path
+			resultsFile = filepath.Join(path, nameTemplate)
+		} else {
+			// Has extension, treat as file
+			resultsFolder = filepath.Dir(path)
+			resultsFile = path
+		}
+	}
+
+	if err := files.CreateFolderIfNotExists(resultsFolder); err != nil {
+		return "", fmt.Errorf("failed to create results folder '%s': %w", resultsFolder, err)
+	}
+
+	return resultsFile, nil
+}
+
+// generateNameTemplate generates a name template for the results file based on the CI mode.
+func (s *Scanner) generateNameTemplate(cfg *config.Config, reportExt string) string {
+	nameTemplate := fmt.Sprintf("scanio-report-%s.%s", s.pluginName, reportExt)
+	if !config.IsCI(cfg) {
+		startTime := time.Now().UTC().Format(time.RFC3339)
+		nameTemplate = fmt.Sprintf("scanio-report-%s-%s.%s", s.pluginName, startTime, reportExt)
+	}
+	return nameTemplate
 }
 
 func (s Scanner) scanRepo(cfg *config.Config, scanArg shared.ScannerScanRequest) (shared.ScannerScanResponse, error) {
@@ -105,7 +159,7 @@ func (s Scanner) scanRepo(cfg *config.Config, scanArg shared.ScannerScanRequest)
 		err    error
 	)
 
-	err = shared.WithPlugin(cfg, "plugin-scanner", shared.PluginTypeScanner, s.scannerPluginName, func(raw interface{}) error {
+	err = shared.WithPlugin(cfg, "plugin-scanner", shared.PluginTypeScanner, s.pluginName, func(raw interface{}) error {
 		scanner := raw.(shared.Scanner)
 		result, err = scanner.Scan(scanArg)
 		if err != nil {
@@ -120,7 +174,7 @@ func (s Scanner) scanRepo(cfg *config.Config, scanArg shared.ScannerScanRequest)
 
 func (s Scanner) ScanRepos(cfg *config.Config, scanArgs []shared.ScannerScanRequest) shared.GenericLaunchesResult {
 
-	s.logger.Info("Scan starting", "total", len(scanArgs), "goroutines", s.jobs)
+	s.logger.Info("Scan starting", "total", len(scanArgs), "goroutines", s.concurrentJobs)
 
 	var results shared.GenericLaunchesResult
 	resultsChannel := make(chan shared.GenericResult, len(scanArgs))
@@ -129,7 +183,7 @@ func (s Scanner) ScanRepos(cfg *config.Config, scanArgs []shared.ScannerScanRequ
 		values[i] = scanArgs[i]
 	}
 
-	shared.ForEveryStringWithBoundedGoroutines(s.jobs, values, func(i int, value interface{}) {
+	shared.ForEveryStringWithBoundedGoroutines(s.concurrentJobs, values, func(i int, value interface{}) {
 		scanArg := value.(shared.ScannerScanRequest)
 		s.logger.Info("Goroutine started", "#", i+1, "args", scanArg)
 

--- a/pkg/shared/config/common.go
+++ b/pkg/shared/config/common.go
@@ -80,10 +80,15 @@ func GetRepositoryPath(cfg *Config, VCSURL, repoWithNamespace string) string {
 
 // GetPRTempPath constructs the path to the temporary folder for a pull request based on the VCS URL, namespace, and repository name.
 func GetPRTempPath(cfg *Config, VCSURL, Namespace, RepoName string, PRId int) string {
-	rawStartTime := time.Now().UTC()
-	startTime := rawStartTime.Format(time.RFC3339)
-	return filepath.Join(GetScanioTempHome(cfg), strings.ToLower(VCSURL), strings.ToLower(Namespace),
-		strings.ToLower(RepoName), "scanio-pr-tmp", strconv.Itoa(PRId), startTime)
+	basePath := filepath.Join(GetScanioTempHome(cfg), strings.ToLower(VCSURL), strings.ToLower(Namespace), strings.ToLower(RepoName), "scanio-pr-tmp", strconv.Itoa(PRId))
+
+	// Append timestamp if not in CI environment
+	if !IsCI(cfg) {
+		startTime := time.Now().UTC().Format(time.RFC3339)
+		return filepath.Join(basePath, startTime)
+	}
+
+	return basePath
 }
 
 // GetScanioMode returns the Scanio mode from the configuration.

--- a/pkg/shared/files/utils.go
+++ b/pkg/shared/files/utils.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 )
 
-// expandPath resolves paths that include a tilde (~) to the user's home directory.
+// ExpandPath resolves paths that include a tilde (~) to the user's home directory.
 func ExpandPath(path string) (string, error) {
 	if strings.HasPrefix(path, "~/") {
 		homeDir, err := os.UserHomeDir()
@@ -23,7 +23,7 @@ func ExpandPath(path string) (string, error) {
 	return path, nil
 }
 
-// ValidateConfigPath checks if the given path is a valid file path for reading.
+// ValidatePath checks if the given path is a valid file path for reading.
 func ValidatePath(path string) error {
 	info, err := os.Stat(path)
 	if err != nil {

--- a/pkg/shared/files/utils.go
+++ b/pkg/shared/files/utils.go
@@ -66,7 +66,7 @@ func CopyDotFiles(src, dst string, logger hclog.Logger) error {
 					return err
 				}
 			} else {
-				if err := Copy(srcPath, dst); err != nil {
+				if err := Copy(srcPath, dstPath); err != nil {
 					logger.Error("error copying file", "path", srcPath, "error", err)
 					return err
 				}

--- a/pkg/shared/iscanner.go
+++ b/pkg/shared/iscanner.go
@@ -19,12 +19,13 @@ type ScannerScanResult struct {
 	Message string
 }
 
+// ScannerScanRequest represents a single scan request.
 type ScannerScanRequest struct {
-	RepoPath       string
-	ReportFormat   string
-	ConfigPath     string
-	ResultsPath    string
-	AdditionalArgs []string
+	TargetPath     string   // Path to the target to scan
+	ResultsPath    string   // Path to save the results of the scan
+	ConfigPath     string   // Path to the configuration file for the scanner
+	ReportFormat   string   // Format of the report to generate (e.g., JSON, Sarif)
+	AdditionalArgs []string // Additional arguments for the scanner
 }
 
 type ScannerScanResponse struct {

--- a/pkg/shared/utils.go
+++ b/pkg/shared/utils.go
@@ -2,7 +2,6 @@ package shared
 
 import (
 	"bufio"
-	"bytes"
 	"encoding/json"
 	"fmt"
 
@@ -11,22 +10,11 @@ import (
 	"os"
 	"path"
 	"strings"
-	"text/template"
 
 	"github.com/hashicorp/go-hclog"
 )
 
 type CustomData interface{}
-
-type ScanReportData struct {
-	ScanStarted  bool
-	ScanPassed   bool
-	ScanFailed   bool
-	ScanCrashed  bool
-	ScanDetails  interface{}
-	ScanResults  interface{}
-	ErrorDetails interface{}
-}
 
 func WriteJsonFile(outputFile string, logger hclog.Logger, data ...CustomData) {
 	file, err := os.OpenFile(outputFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
@@ -170,32 +158,4 @@ func ContainsSubstring(target string, substrings []string) bool {
 		}
 	}
 	return false
-}
-
-func loadTemplateFromFile(filename string) (*template.Template, error) {
-	templateData, err := os.ReadFile(filename)
-	if err != nil {
-		return nil, err
-	}
-
-	tpl, err := template.New("comment").Parse(string(templateData))
-	if err != nil {
-		return nil, err
-	}
-	return tpl, nil
-}
-
-func CommentBuilder(data interface{}, path string) (string, error) {
-
-	template, err := loadTemplateFromFile(path)
-	if err != nil {
-		return "", err
-	}
-
-	var result bytes.Buffer
-	if err := template.Execute(&result, data); err != nil {
-		return "", err
-	}
-
-	return result.String(), nil
 }

--- a/plugins/bandit/bandit.go
+++ b/plugins/bandit/bandit.go
@@ -27,7 +27,7 @@ type ScannerBandit struct {
 
 func (g *ScannerBandit) Scan(args shared.ScannerScanRequest) (shared.ScannerScanResponse, error) {
 	var result shared.ScannerScanResponse
-	g.logger.Info("Scan is starting", "project", args.RepoPath)
+	g.logger.Info("Scan is starting", "project", args.TargetPath)
 	g.logger.Debug("Debug info", "args", args)
 
 	var commandArgs []string
@@ -46,7 +46,7 @@ func (g *ScannerBandit) Scan(args shared.ScannerScanRequest) (shared.ScannerScan
 		commandArgs = append(commandArgs, "-c", args.ConfigPath)
 	}
 
-	cmd := exec.Command("bandit", "-r", "-o", args.ResultsPath, args.RepoPath)
+	cmd := exec.Command("bandit", "-r", "-o", args.ResultsPath, args.TargetPath)
 	g.logger.Debug("Debug info", "cmd", cmd.Args)
 
 	mw := io.MultiWriter(g.logger.StandardWriter(&hclog.StandardLoggerOptions{
@@ -65,9 +65,9 @@ func (g *ScannerBandit) Scan(args shared.ScannerScanRequest) (shared.ScannerScan
 		}
 	}
 	result.ResultsPath = args.ResultsPath
-	g.logger.Info("Scan finished for", "project", args.RepoPath)
+	g.logger.Info("Scan finished for", "project", args.TargetPath)
 	g.logger.Info("Result is saved to", "path to a result file", args.ResultsPath)
-	g.logger.Debug("Debug info", "project", args.RepoPath, "config", args.ConfigPath, "resultsFile", args.ResultsPath, "cmd", cmd.Args)
+	g.logger.Debug("Debug info", "project", args.TargetPath, "config", args.ConfigPath, "resultsFile", args.ResultsPath, "cmd", cmd.Args)
 	return result, nil
 }
 

--- a/plugins/bitbucket/bitbucket.go
+++ b/plugins/bitbucket/bitbucket.go
@@ -187,13 +187,13 @@ func (g *VCSBitbucket) SetStatusOfPR(args shared.VCSSetStatusOfPRRequest) (bool,
 	}
 	g.logger.Info("changing status of a particular PR", "PR", fmt.Sprintf("%v/%v/%v/%v", args.VCSURL, args.Namespace, args.Repository, args.PullRequestId))
 
-	user, err := prData.SetStatus(args.Status, args.Login)
+	_, err = prData.SetStatus(args.Status, args.Login)
 	if err != nil {
 		g.logger.Error("failed to set the status of the PR", "error", err)
 		return false, err
 	}
 
-	g.logger.Info("PR successfully moved to status", "status", args.Status, "PR_id", args.PullRequestId, "last_commit", user.Author.LastReviewedCommit)
+	g.logger.Info("PR successfully moved to status", "status", args.Status, "PR_id", args.PullRequestId, "last_commit", prData.Author.LastReviewedCommit)
 	return true, nil
 }
 

--- a/plugins/bitbucket/bitbucket.go
+++ b/plugins/bitbucket/bitbucket.go
@@ -265,7 +265,7 @@ func (g *VCSBitbucket) fetchPR(args *shared.VCSFetchRequest) (string, error) {
 		return "", err
 	}
 
-	baseDestPath := config.GetPRTempPath(g.globalConfig, args.RepoParam.VCSURL, (args.RepoParam.Namespace), args.RepoParam.RepoName, prID)
+	baseDestPath := config.GetPRTempPath(g.globalConfig, args.RepoParam.VCSURL, args.RepoParam.Namespace, args.RepoParam.RepoName, prID)
 
 	g.logger.Debug("copying files that have changed")
 	for _, val := range *changes {

--- a/plugins/codeql/codeql.go
+++ b/plugins/codeql/codeql.go
@@ -45,14 +45,14 @@ func (g *ScannerCodeQL) createDatabase(databaseDir string, args shared.ScannerSc
 
 	var stdBuffer bytes.Buffer
 
-	g.logger.Debug("Creating CodeQL database", "project", args.RepoPath)
+	g.logger.Debug("Creating CodeQL database", "project", args.TargetPath)
 
 	language := os.Getenv("SCANIO_CODEQL_LANGUAGE")
 	if !isLanguageSupported(language) {
 		return fmt.Errorf("unsupported language for CodeQL")
 	}
 
-	commandArgs := []string{"database", "create", databaseDir, "--language", language, "--source-root", args.RepoPath}
+	commandArgs := []string{"database", "create", databaseDir, "--language", language, "--source-root", args.TargetPath}
 
 	cmd := exec.Command("codeql", commandArgs...)
 	mw := io.MultiWriter(g.logger.StandardWriter(&hclog.StandardLoggerOptions{
@@ -73,7 +73,7 @@ func (g *ScannerCodeQL) createDatabase(databaseDir string, args shared.ScannerSc
 }
 
 func (g *ScannerCodeQL) analyzeDatabase(databaseDir string, args shared.ScannerScanRequest) error {
-	g.logger.Debug("Analyzing CodeQL database", "project", args.RepoPath)
+	g.logger.Debug("Analyzing CodeQL database", "project", args.TargetPath)
 
 	// codeql database analyze /tmp/scanio.codeqldb/ --format sarifv2.1.0 codeql/go-queries -o /tmp/scanio.sarif
 
@@ -108,7 +108,7 @@ func (g *ScannerCodeQL) analyzeDatabase(databaseDir string, args shared.ScannerS
 
 func (g *ScannerCodeQL) Scan(args shared.ScannerScanRequest) (shared.ScannerScanResponse, error) {
 
-	g.logger.Info("CodeQL flow starting", "project", args.RepoPath)
+	g.logger.Info("CodeQL flow starting", "project", args.TargetPath)
 	g.logger.Debug("Debug info", "args", args)
 
 	databaseDir, err := os.MkdirTemp("", "codeqdb")
@@ -126,9 +126,9 @@ func (g *ScannerCodeQL) Scan(args shared.ScannerScanRequest) (shared.ScannerScan
 	}
 
 	result.ResultsPath = args.ResultsPath
-	g.logger.Info("Scan finished for", "project", args.RepoPath)
+	g.logger.Info("Scan finished for", "project", args.TargetPath)
 	g.logger.Info("Result is saved to", "path to a result file", args.ResultsPath)
-	g.logger.Debug("Debug info", "project", args.RepoPath, "config", args.ConfigPath, "resultsFile", args.ResultsPath)
+	g.logger.Debug("Debug info", "project", args.TargetPath, "config", args.ConfigPath, "resultsFile", args.ResultsPath)
 	return result, nil
 }
 

--- a/plugins/semgrep/semgrep.go
+++ b/plugins/semgrep/semgrep.go
@@ -41,7 +41,7 @@ func (g *ScannerSemgrep) getDefaultConfig() string {
 
 func (g *ScannerSemgrep) Scan(args shared.ScannerScanRequest) (shared.ScannerScanResponse, error) {
 	var result shared.ScannerScanResponse
-	g.logger.Info("Scan is starting", "project", args.RepoPath)
+	g.logger.Info("Scan is starting", "project", args.TargetPath)
 	g.logger.Debug("Debug info", "args", args)
 
 	var commandArgs []string
@@ -77,7 +77,7 @@ func (g *ScannerSemgrep) Scan(args shared.ScannerScanRequest) (shared.ScannerSca
 	commandArgs = append(commandArgs, "--output", args.ResultsPath)
 
 	// repo path
-	commandArgs = append(commandArgs, args.RepoPath)
+	commandArgs = append(commandArgs, args.TargetPath)
 
 	// prep cmd
 	cmd = exec.Command("semgrep", commandArgs...)
@@ -98,9 +98,9 @@ func (g *ScannerSemgrep) Scan(args shared.ScannerScanRequest) (shared.ScannerSca
 	}
 
 	result.ResultsPath = args.ResultsPath
-	g.logger.Info("Scan finished for", "project", args.RepoPath)
+	g.logger.Info("Scan finished for", "project", args.TargetPath)
 	g.logger.Info("Result is saved to", "path to a result file", args.ResultsPath)
-	g.logger.Debug("Debug info", "project", args.RepoPath, "config", args.ConfigPath, "resultsFile", args.ResultsPath, "cmd", cmd.Args)
+	g.logger.Debug("Debug info", "project", args.TargetPath, "config", args.ConfigPath, "resultsFile", args.ResultsPath, "cmd", cmd.Args)
 	return result, nil
 }
 

--- a/plugins/trufflehog/trufflehog.go
+++ b/plugins/trufflehog/trufflehog.go
@@ -34,7 +34,7 @@ func (g *ScannerTrufflehog) Scan(args shared.ScannerScanRequest) (shared.Scanner
 		result      shared.ScannerScanResponse
 	)
 
-	g.logger.Info("Scan is starting", "project", args.RepoPath)
+	g.logger.Info("Scan is starting", "project", args.TargetPath)
 	g.logger.Debug("Debug info", "args", args)
 
 	// Add additional arguments
@@ -53,7 +53,7 @@ func (g *ScannerTrufflehog) Scan(args shared.ScannerScanRequest) (shared.Scanner
 		g.logger.Warn("Trufflehog supports only a json non default format. Will be used default format instead of your reportFormat", "reportFormat", args.ReportFormat)
 	}
 
-	commandArgs = append(commandArgs, "--no-verification", "filesystem", args.RepoPath)
+	commandArgs = append(commandArgs, "--no-verification", "filesystem", args.TargetPath)
 	cmd = exec.Command("trufflehog", commandArgs...)
 	g.logger.Debug("Debug info", "cmd", cmd.Args)
 
@@ -79,10 +79,10 @@ func (g *ScannerTrufflehog) Scan(args shared.ScannerScanRequest) (shared.Scanner
 		return result, err
 	}
 
-	result.ResultsPath = args.RepoPath
-	g.logger.Info("Scan finished for", "project", args.RepoPath)
+	result.ResultsPath = args.TargetPath
+	g.logger.Info("Scan finished for", "project", args.TargetPath)
 	g.logger.Info("Result is saved to", "path to a result file", args.ResultsPath)
-	g.logger.Debug("Debug info", "project", args.RepoPath, "config", args.ConfigPath, "resultsFile", args.ResultsPath, "cmd", cmd.Args)
+	g.logger.Debug("Debug info", "project", args.TargetPath, "config", args.ConfigPath, "resultsFile", args.ResultsPath, "cmd", cmd.Args)
 	return result, nil
 }
 

--- a/plugins/trufflehog3/trufflehog3.go
+++ b/plugins/trufflehog3/trufflehog3.go
@@ -34,7 +34,7 @@ func (g *ScannerTrufflehog3) Scan(args shared.ScannerScanRequest) (shared.Scanne
 		result      shared.ScannerScanResponse
 	)
 
-	g.logger.Info("Scan is starting", "project", args.RepoPath)
+	g.logger.Info("Scan is starting", "project", args.TargetPath)
 	g.logger.Debug("Debug info", "args", args)
 
 	// Add additional arguments
@@ -54,7 +54,7 @@ func (g *ScannerTrufflehog3) Scan(args shared.ScannerScanRequest) (shared.Scanne
 	}
 
 	// Here we added -z flag because Trufflehog3 sends a not correct exit code even when it finished without errors
-	commandArgs = append(commandArgs, "-z", "--output", args.ResultsPath, args.RepoPath)
+	commandArgs = append(commandArgs, "-z", "--output", args.ResultsPath, args.TargetPath)
 
 	cmd = exec.Command("trufflehog3", commandArgs...)
 	g.logger.Debug("Debug info", "cmd", cmd.Args)
@@ -74,9 +74,9 @@ func (g *ScannerTrufflehog3) Scan(args shared.ScannerScanRequest) (shared.Scanne
 	}
 
 	result.ResultsPath = args.ResultsPath
-	g.logger.Info("Scan finished for", "project", args.RepoPath)
+	g.logger.Info("Scan finished for", "project", args.TargetPath)
 	g.logger.Info("Result is saved to", "path to a result file", args.ResultsPath)
-	g.logger.Debug("Debug info", "project", args.RepoPath, "config", args.ConfigPath, "resultsFile", args.ResultsPath, "cmd", cmd.Args)
+	g.logger.Debug("Debug info", "project", args.TargetPath, "config", args.ConfigPath, "resultsFile", args.ResultsPath, "cmd", cmd.Args)
 	return result, nil
 }
 

--- a/templates/comments_template.groovy
+++ b/templates/comments_template.groovy
@@ -1,0 +1,33 @@
+<% if (ScanStarted) { %>
+### 🔄 **Security scan started**
+
+#### Scan details
+<%= ScanDetails %>
+<% } %>
+
+<% if (ScanPassed) { %>
+### ✅ Security scan passed
+
+#### Scan details
+<%= ScanDetails %>
+<% } %>
+
+<% if (ScanFailed) { %>
+### ❌ Security scan failed
+
+#### Results of the scan
+<%= ScanResults %>
+
+#### Scan details
+<%= ScanDetails %>
+<% } %>
+
+<% if (ScanCrashed) { %>
+### 🚧 Security scan crashed
+
+#### Error details
+<%= ErrorDetails %>
+
+#### Scan details
+<%= ScanDetails %>
+<% } %>


### PR DESCRIPTION
## CI Features
### Extended CI Mode
The CI mode was extended to accommodate environments that can be set up with the following configuration:
```yaml
# config.yml
scanio:
  mode: "ci"
```

Or by setting environment variables `SCANIO_MODE` or `CI` to true.

In CI mode, filenames and paths will no longer include timestamps. This allows users to know the location of files and necessary paths in advance without needing to parse the output of scanio commands.

For temporary files used in PR fetching, the path will not contain timestamps.
  
 ## Leaving Comments from a File
In `integration-vcs.go`, a new feature was supported that allows taking comments from a file for commenting on PRs. This is useful for long and multiline comments.

Command example:
```
scanio integration-vcs --vcs bitbucket --action addComment --vcs-url git.example.com --namespace test --repository test --pull-request-id 1 --comment-file /path/to/file
```

## Analyze Output File Feature
Added a parsing output flag for the analyze command to choose between file or folder. The new logic includes:
- Check if the provided path exists and is a directory:
  - If the path exists and is a folder, the report name will be generated by the orchestrator.
- Check if the provided path is a file or does not exist:
  - If the path has no extension, the core will treat it as a directory and generate the report name accordingly.
  - If the path has an extension, the name will be passed to the scanner as is.
  - If the path is considered a directory by the scanner and does not exist, the necessary folders will be created.

## Comment File for Jenkins
Added a base template in Groovy format for the Jenkins environment.

## Others

- Refactored Dockerfile: removed redundant directives.
- Refactoring of `analyse.go`: improved comments and flag descriptions.
- Refactored `integration-vcs.go`: improved comments and variable names.
- Refactoring in `internal/scanner/scanner.go and pkg/shared/iscanner.go`: improved names of structures and variables, added comments.
- Deleted redundant code from the decision-maker.
- Fixed a bug in `SetStatusOfPr` in Bitbucket plugin.
- Addressed an issue with fetching of dot files in PRs.

