### PR TITLE
remove config.yml in working dir from default lookup paths list

### DIFF
--- a/pkg/shared/config/config.go
+++ b/pkg/shared/config/config.go
@@ -116,7 +116,6 @@ func LoadConfig(configPath string) (*Config, error) {
 // searchDefaultConfig searches for a config file in default paths.
 func (c *Config) searchDefaultConfig() error {
 	defaultPaths := []string{
-		"config.yml",           // Development default path
 		"~/.scanio/config.yml", // Local install default path
 		"/scanio/config.yml",   // Docker default path
 	}


### PR DESCRIPTION
config.yml in working dir can be confused with config.yml of scanned project. The issue is especially clear for ci pipelines, when project source code is a working directory by default. The same issue can be experienced with scanning when scanio scans scanio repo, because it has a config.yml in the root. This type of "config hijacking" lead to incorrect configuration, may result in incorrect behavior, and potentially even security issues.