### PR TITLE
Fix incorrect command building for trufflehog plugin when additional args are specified

### DIFF
--- a/plugins/trufflehog/VERSION
+++ b/plugins/trufflehog/VERSION
@@ -1,4 +1,4 @@
 {
-  "version": "0.0.1",
+  "version": "0.0.2",
   "plugin_type": "scanner"
 }

--- a/plugins/trufflehog/trufflehog.go
+++ b/plugins/trufflehog/trufflehog.go
@@ -59,6 +59,8 @@ func (g *ScannerTrufflehog) buildCommandArgs(args shared.ScannerScanRequest) []s
 
 	appendArg("--no-verification", "filesystem")
 
+	// additional arguments should be added after command name
+	// ref: https://github.com/scan-io-git/scan-io/issues/86
 	if len(args.AdditionalArgs) != 0 {
 		appendArg(args.AdditionalArgs...)
 	}

--- a/plugins/trufflehog/trufflehog.go
+++ b/plugins/trufflehog/trufflehog.go
@@ -48,10 +48,6 @@ func (g *ScannerTrufflehog) buildCommandArgs(args shared.ScannerScanRequest) []s
 		commandArgs = append(commandArgs, arg...)
 	}
 
-	if len(args.AdditionalArgs) != 0 {
-		appendArg(args.AdditionalArgs...)
-	}
-
 	if args.ConfigPath != "" {
 		appendArg("--config", args.ConfigPath)
 	}
@@ -62,6 +58,11 @@ func (g *ScannerTrufflehog) buildCommandArgs(args shared.ScannerScanRequest) []s
 	}
 
 	appendArg("--no-verification", "filesystem")
+
+	if len(args.AdditionalArgs) != 0 {
+		appendArg(args.AdditionalArgs...)
+	}
+
 	appendArg(args.TargetPath)
 	return commandArgs
 }


### PR DESCRIPTION
Fix incorrect command building for trufflehog plugin when additional args are specified.  

More details: https://github.com/scan-io-git/scan-io/issues/86