### PR TITLE
Japroc/correct ssh url in html reports

### DIFF
--- a/cmd/to-html.go
+++ b/cmd/to-html.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	// "html/template"
+	"html/template"
 	"os"
 	"path/filepath"
 	"time"
@@ -10,9 +10,10 @@ import (
 
 	"github.com/scan-io-git/scan-io/internal/git"
 	scaniosarif "github.com/scan-io-git/scan-io/internal/sarif"
-	"github.com/scan-io-git/scan-io/internal/template"
+	scaniotemplate "github.com/scan-io-git/scan-io/internal/template"
 	"github.com/scan-io-git/scan-io/pkg/shared/files"
 	"github.com/scan-io-git/scan-io/pkg/shared/logger"
+	"github.com/scan-io-git/scan-io/pkg/shared/vcsurl"
 )
 
 type ToHTMLOptions struct {
@@ -36,6 +37,14 @@ type ReportMetadata struct {
 
 var execExampleToHTML = `  # Generate html report for semgrep sarif output
   scanio to-html --input /tmp/juice-shop/semgrep.sarif --output /tmp/juice-shop/semgrep.html --source /tmp/juice-shop`
+
+func gitURLtoWebURL(gitURL string) string {
+	u, err := vcsurl.Parse(gitURL)
+	if err != nil {
+		return gitURL
+	}
+	return u.HTTPRepoLink
+}
 
 // toHtmlCmd represents the toHtml command
 var toHtmlCmd = &cobra.Command{
@@ -88,7 +97,7 @@ var toHtmlCmd = &cobra.Command{
 			return err
 		}
 
-		tmpl, err := template.NewTemplate(templateFile)
+		tmpl, err := scaniotemplate.NewTemplate(templateFile, scaniotemplate.WithFuncs(template.FuncMap{"gitURLtoWebURL": gitURLtoWebURL}))
 		if err != nil {
 			return err
 		}

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -44,12 +44,21 @@ func formatDateTime(t time.Time) string {
 	return fmt.Sprintf("%s %s %d %d:%02d:%02d %s", day, t.Month(), t.Year(), t.Hour()%12, t.Minute(), t.Second(), t.Format("pm"))
 }
 
-func NewTemplate(templateFile string) (*template.Template, error) {
-	return template.New("report.html").
+func NewTemplate(templateFile string, options ...func(*template.Template)) (*template.Template, error) {
+	t := template.New("report.html").
 		Funcs(template.FuncMap{
 			"add":              add,
 			"generateSequence": generateSequence,
 			"formatDateTime":   formatDateTime,
-		}).
-		ParseFiles(templateFile)
+		})
+	for _, o := range options {
+		o(t)
+	}
+	return t.ParseFiles(templateFile)
+}
+
+func WithFuncs(funcs template.FuncMap) func(*template.Template) {
+	return func(t *template.Template) {
+		t.Funcs(funcs)
+	}
 }

--- a/templates/tohtml/report.html
+++ b/templates/tohtml/report.html
@@ -223,6 +223,7 @@
 </head>
 
 {{ $repo := .Metadata.RepositoryMetadata.RepositoryFullName }}
+{{ $webURL := gitURLtoWebURL $repo }}
 {{ $branch := .Metadata.RepositoryMetadata.BranchName }}
 {{ $commit := .Metadata.RepositoryMetadata.CommitHash }}
 
@@ -262,9 +263,9 @@
         <p><b>Time:</b> {{ .Metadata.Time | formatDateTime }} (UTC)</p>
         <p><b>Tool:</b> {{ .Metadata.ToolMetadata.Name }} {{if .Metadata.ToolMetadata.Version}}{{ .Metadata.ToolMetadata.Version }}{{end}}</p>
         {{if .Metadata.SourceFolder}}<p><b>Source:</b> {{ .Metadata.SourceFolder }}</p>{{end}}
-        {{if $repo}}<p><b>Repository:</b> <a href="{{ $repo }}">{{ $repo }}</a></p>{{end}}
-        {{if $branch}}<p><b>Branch:</b> {{if $repo}}<a href="{{- $repo -}}/tree/{{- $branch -}}">{{ $branch }}</a>{{else}}{{ $branch }}{{end}} </p>{{end}}
-        {{if $commit}}<p><b>Commit:</b> {{if $repo}}<a href="{{- $repo -}}/tree/{{- $commit -}}">{{ $commit }}</a>{{else}}{{ $commit }}{{end}} </p>{{end}}
+        {{if $repo}}<p><b>Repository:</b> <a href="{{ $webURL }}">{{ $repo }}</a></p>{{end}}
+        {{if $branch}}<p><b>Branch:</b> {{if $webURL}}<a href="{{- $webURL -}}/tree/{{- $branch -}}">{{ $branch }}</a>{{else}}{{ $branch }}{{end}} </p>{{end}}
+        {{if $commit}}<p><b>Commit:</b> {{if $webURL}}<a href="{{- $webURL -}}/tree/{{- $commit -}}">{{ $commit }}</a>{{else}}{{ $commit }}{{end}} </p>{{end}}
         {{if .Metadata.RepositoryMetadata.Subfolder}}<p><b>Subfolder:</b> {{ .Metadata.RepositoryMetadata.Subfolder }} </p>{{end}}
       </div> 
     </div>
@@ -290,7 +291,7 @@
               <p>{{index .Properties "Description"}}</p>
               {{ $location := index .Locations 0}}
               {{ $locationString := index .Locations 0}}
-              <div class="issue-card__body__metadata__location">Location: <strong>{{if (and $repo $commit)}}<a href="{{- $repo -}}/blob/{{- $commit -}}/{{- $location.PhysicalLocation.ArtifactLocation.URI -}}#L{{- $location.PhysicalLocation.Region.StartLine -}}">{{$location.PhysicalLocation.ArtifactLocation.URI}} (line : {{$location.PhysicalLocation.Region.StartLine}})</a> {{else}} {{$location.PhysicalLocation.ArtifactLocation.URI}} (line : {{$location.PhysicalLocation.Region.StartLine}}){{end}}</strong></div>
+              <div class="issue-card__body__metadata__location">Location: <strong>{{if (and $webURL $commit)}}<a href="{{- $webURL -}}/blob/{{- $commit -}}/{{- $location.PhysicalLocation.ArtifactLocation.URI -}}#L{{- $location.PhysicalLocation.Region.StartLine -}}">{{$location.PhysicalLocation.ArtifactLocation.URI}} (line : {{$location.PhysicalLocation.Region.StartLine}})</a> {{else}} {{$location.PhysicalLocation.ArtifactLocation.URI}} (line : {{$location.PhysicalLocation.Region.StartLine}}){{end}}</strong></div>
             </div>
             <div class="issue-card__body__dataflows">
               <header class="card__body__dataflows__header">
@@ -332,8 +333,8 @@
 
                         <div class="issue-card__body__dataflows__codeline">
 
-                          {{if (and $repo $commit)}}
-                            <span class="issue-card__body__dataflows__codeline__linecol"><a href="{{- $repo -}}/blob/{{- $commit -}}/{{- $curUri -}}#L{{- $startLine -}}">{{$startLine}}:{{$startColumn}}</a></span>
+                          {{if (and $webURL $commit)}}
+                            <span class="issue-card__body__dataflows__codeline__linecol"><a href="{{- $webURL -}}/blob/{{- $commit -}}/{{- $curUri -}}#L{{- $startLine -}}">{{$startLine}}:{{$startColumn}}</a></span>
                           {{else}}
                             <span class="issue-card__body__dataflows__codeline__linecol">{{$startLine}}:{{$startColumn}}</span>
                           {{end}}


### PR DESCRIPTION
There was an issue https://github.com/scan-io-git/scan-io/issues/89 about incorrect parsing of SSH urls, and building incorrect hyperlinks in html reports.

This MR improves template library, which now supports optional functions.

to-html uses this new functionality to pass a function to convert git URL to web URL. And then use this url for correct code line hyperlinks.