### PR TITLE
fix to-html locations for report with absolute paths

### DIFF
--- a/cmd/to-html.go
+++ b/cmd/to-html.go
@@ -83,12 +83,17 @@ var toHtmlCmd = &cobra.Command{
 
 		severityInfo := sarifReport.CollectSeverityInfo()
 
+		metadataSourceFolder := allToHTMLOptions.SourceFolder
+		if config.IsCI(AppConfig) {
+			metadataSourceFolder = ""
+		}
+
 		metadata := &ReportMetadata{
 			RepositoryMetadata: *repositoryMetadata,
 			ToolMetadata:       *toolMetadata,
 			Title:              allToHTMLOptions.Title,
 			Time:               time.Now().UTC(),
-			SourceFolder:       allToHTMLOptions.SourceFolder,
+			SourceFolder:       metadataSourceFolder,
 			SeverityInfo:       severityInfo,
 		}
 		logger.Debug("metadata", "metadata", *metadata)

--- a/cmd/to-html.go
+++ b/cmd/to-html.go
@@ -9,11 +9,13 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/scan-io-git/scan-io/internal/git"
-	scaniosarif "github.com/scan-io-git/scan-io/internal/sarif"
-	scaniotemplate "github.com/scan-io-git/scan-io/internal/template"
+	"github.com/scan-io-git/scan-io/pkg/shared/config"
 	"github.com/scan-io-git/scan-io/pkg/shared/files"
 	"github.com/scan-io-git/scan-io/pkg/shared/logger"
 	"github.com/scan-io-git/scan-io/pkg/shared/vcsurl"
+
+	scaniosarif "github.com/scan-io-git/scan-io/internal/sarif"
+	scaniotemplate "github.com/scan-io-git/scan-io/internal/template"
 )
 
 type ToHTMLOptions struct {
@@ -92,6 +94,10 @@ var toHtmlCmd = &cobra.Command{
 		logger.Debug("metadata", "metadata", *metadata)
 
 		// parse html template and generate report file with metadata
+		if allToHTMLOptions.TempatesPath == "" {
+			allToHTMLOptions.TempatesPath = filepath.Join(config.GetScanioHome(AppConfig), "templates/tohtml/")
+		}
+
 		templateFile, err := files.ExpandPath(filepath.Join(allToHTMLOptions.TempatesPath, "report.html"))
 		if err != nil {
 			return err
@@ -128,7 +134,7 @@ var toHtmlCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(toHtmlCmd)
 
-	toHtmlCmd.Flags().StringVarP(&allToHTMLOptions.TempatesPath, "templates-path", "t", "./templates/tohtml", "path to folder with templates")
+	toHtmlCmd.Flags().StringVarP(&allToHTMLOptions.TempatesPath, "templates-path", "t", "", "path to folder with templates")
 	toHtmlCmd.Flags().StringVar(&allToHTMLOptions.Title, "title", "Scanio Report", "title for generated html file")
 	toHtmlCmd.Flags().StringVarP(&allToHTMLOptions.Input, "input", "i", "", "input file with sarif report")
 	toHtmlCmd.Flags().StringVarP(&allToHTMLOptions.OutputFile, "output", "o", "scanio-report.html", "outoput file")

--- a/internal/sarif/sarif.go
+++ b/internal/sarif/sarif.go
@@ -288,7 +288,7 @@ func (r Report) EnrichResultsLevelProperty() {
 	}
 }
 
-func (r Report) EnrichResultsURIProperty() {
+func (r Report) EnrichResultsLocationURIProperty() {
 	for _, result := range r.Runs[0].Results {
 		// if result location length is at least 1
 		if len(result.Locations) > 0 {
@@ -321,6 +321,7 @@ func (r Report) EnrichResultsProperties() {
 	r.EnrichResultsTitleProperty()
 	r.EnrichResultsCodeFlowProperty()
 	r.EnrichResultsLevelProperty()
+	r.EnrichResultsLocationURIProperty()
 }
 
 // SortResultsByLevel function sorts sarif results by level

--- a/templates/tohtml/report.html
+++ b/templates/tohtml/report.html
@@ -291,8 +291,9 @@
             <div class="issue-card__body__metadata severity--{{$level}}">
               <p>{{index .Properties "Description"}}</p>
               {{ $location := index .Locations 0}}
-              {{ $locationString := index .Locations 0}}
-              <div class="issue-card__body__metadata__location">Location: <strong>{{if (and $webURL $commit)}}<a href="{{- $webURL -}}/blob/{{- $commit -}}/{{- $location.PhysicalLocation.ArtifactLocation.URI -}}#L{{- $location.PhysicalLocation.Region.StartLine -}}">{{$location.PhysicalLocation.ArtifactLocation.URI}} (line : {{$location.PhysicalLocation.Region.StartLine}})</a> {{else}} {{$location.PhysicalLocation.ArtifactLocation.URI}} (line : {{$location.PhysicalLocation.Region.StartLine}}){{end}}</strong></div>
+              {{ $locationURI := index $location.PhysicalLocation.ArtifactLocation.Properties "URI"}}
+              {{ $locationStartLine := $location.PhysicalLocation.Region.StartLine }}
+              <div class="issue-card__body__metadata__location">Location: <strong>{{if (and $webURL $commit)}}<a href="{{- $webURL -}}/blob/{{- $commit -}}/{{- $locationURI -}}#L{{- $locationStartLine -}}">{{$locationURI}} (line : {{$locationStartLine}})</a> {{else}} {{$locationURI}} (line : {{$locationStartLine}}){{end}}</strong></div>
             </div>
             <div class="issue-card__body__dataflows">
               <header class="card__body__dataflows__header">


### PR DESCRIPTION
Solving issue #95 .

The solution is to construct correct relative paths for each location and put it into custom property "URI".