### PR TITLE
#96: move weburl logic from template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,5 @@ __debug_bin*
 # reports
 *.sarif
 *.json
-scanio-report.html
-snyk-to-html-report.html
-report.html
+*report.html
+*results.html

--- a/cmd/to-html.go
+++ b/cmd/to-html.go
@@ -45,6 +45,8 @@ type ReportMetadata struct {
 var execExampleToHTML = `  # Generate html report for semgrep sarif output
   scanio to-html --input /tmp/juice-shop/semgrep.sarif --output /tmp/juice-shop/semgrep.html --source /tmp/juice-shop`
 
+// generic function to convert git URL to web URL
+// will implement vcs specific logic here if needed
 func gitURLtoWebURL(gitURL string) string {
 	u, err := vcsurl.Parse(gitURL)
 	if err != nil {
@@ -53,17 +55,15 @@ func gitURLtoWebURL(gitURL string) string {
 	return u.HTTPRepoLink
 }
 
+// this function will implement vcs specific logic to generate web URL to branch
 func buildWebURLToBranch(webURL, branch string) string {
 	return filepath.Join(webURL, "tree", branch)
 }
 
+// this function will implement vcs specific logic to generate web URL to commit
 func buildWebURLToCommit(webURL, commit string) string {
 	return filepath.Join(webURL, "tree", commit)
 }
-
-// func locationWebURLCB() string {
-// 	return "test"
-// }
 
 // toHtmlCmd represents the toHtml command
 var toHtmlCmd = &cobra.Command{
@@ -106,7 +106,10 @@ var toHtmlCmd = &cobra.Command{
 		}
 
 		// enrich sarif report with additional properties and remove duplicates from dataflow results
-		sarifReport.EnrichResultsProperties(locationWebURLCallback)
+		sarifReport.EnrichResultsTitleProperty()
+		sarifReport.EnrichResultsCodeFlowProperty(locationWebURLCallback)
+		sarifReport.EnrichResultsLevelProperty()
+		sarifReport.EnrichResultsLocationURIProperty(locationWebURLCallback)
 		sarifReport.SortResultsByLevel()
 		sarifReport.RemoveDataflowDuplicates()
 

--- a/cmd/to-html.go
+++ b/cmd/to-html.go
@@ -93,7 +93,7 @@ var toHtmlCmd = &cobra.Command{
 		// we need it because neither sarif nor git modules know anything about vcs web URL structures.
 		// so we should implement vcs scpecific logic here
 		// for beginning I started with generic/github implementation
-		locationWebURLCB := func(location *sarif.Location) string {
+		locationWebURLCallback := func(location *sarif.Location) string {
 			// verify that location.PhysicalLocation.ArtifactLocation.Properties["URI"] is not nil
 			if location.PhysicalLocation.ArtifactLocation.Properties["URI"] == nil {
 				return ""
@@ -106,7 +106,7 @@ var toHtmlCmd = &cobra.Command{
 		}
 
 		// enrich sarif report with additional properties and remove duplicates from dataflow results
-		sarifReport.EnrichResultsProperties(locationWebURLCB)
+		sarifReport.EnrichResultsProperties(locationWebURLCallback)
 		sarifReport.SortResultsByLevel()
 		sarifReport.RemoveDataflowDuplicates()
 

--- a/internal/sarif/sarif.go
+++ b/internal/sarif/sarif.go
@@ -229,7 +229,7 @@ func (r Report) readLineFromFile(loc *sarif.PhysicalLocation) (string, error) {
 }
 
 // EnrichResultsCodeFlowProperty function enriches code flow location properties with source code and URI values
-func (r Report) EnrichResultsCodeFlowProperty() {
+func (r Report) EnrichResultsCodeFlowProperty(locationWebURLCallback func(artifactLocation *sarif.Location) string) {
 
 	for _, result := range r.Runs[0].Results {
 
@@ -254,6 +254,11 @@ func (r Report) EnrichResultsCodeFlowProperty() {
 						r.logger.Debug("can't read source file", "err", err)
 						continue
 					}
+
+					if location.Location.Properties == nil {
+						location.Location.Properties = make(map[string]interface{})
+					}
+					location.Location.Properties["WebURL"] = locationWebURLCallback(location.Location)
 				}
 			}
 		}
@@ -288,7 +293,7 @@ func (r Report) EnrichResultsLevelProperty() {
 	}
 }
 
-func (r Report) EnrichResultsLocationURIProperty(locationWebURLCB func(artifactLocation *sarif.Location) string) {
+func (r Report) EnrichResultsLocationURIProperty(locationWebURLCallback func(artifactLocation *sarif.Location) string) {
 	for _, result := range r.Runs[0].Results {
 		// if result location length is at least 1
 		if len(result.Locations) > 0 {
@@ -311,7 +316,10 @@ func (r Report) EnrichResultsLocationURIProperty(locationWebURLCB func(artifactL
 					}
 				}
 
-				artifactLocation.Properties["WebURL"] = locationWebURLCB(location)
+				if location.Properties == nil {
+					location.Properties = make(map[string]interface{})
+				}
+				location.Properties["WebURL"] = locationWebURLCallback(location)
 			}
 		}
 	}
@@ -319,11 +327,11 @@ func (r Report) EnrichResultsLocationURIProperty(locationWebURLCB func(artifactL
 
 // EnrichResultsProperties function enriches sarif results properties with title, description, location and level values
 // for better html report representation
-func (r Report) EnrichResultsProperties(locationWebURLCB func(artifactLocation *sarif.Location) string) {
+func (r Report) EnrichResultsProperties(locationWebURLCallback func(artifactLocation *sarif.Location) string) {
 	r.EnrichResultsTitleProperty()
-	r.EnrichResultsCodeFlowProperty()
+	r.EnrichResultsCodeFlowProperty(locationWebURLCallback)
 	r.EnrichResultsLevelProperty()
-	r.EnrichResultsLocationURIProperty(locationWebURLCB)
+	r.EnrichResultsLocationURIProperty(locationWebURLCallback)
 }
 
 // SortResultsByLevel function sorts sarif results by level

--- a/internal/sarif/sarif.go
+++ b/internal/sarif/sarif.go
@@ -325,15 +325,6 @@ func (r Report) EnrichResultsLocationURIProperty(locationWebURLCallback func(art
 	}
 }
 
-// EnrichResultsProperties function enriches sarif results properties with title, description, location and level values
-// for better html report representation
-func (r Report) EnrichResultsProperties(locationWebURLCallback func(artifactLocation *sarif.Location) string) {
-	r.EnrichResultsTitleProperty()
-	r.EnrichResultsCodeFlowProperty(locationWebURLCallback)
-	r.EnrichResultsLevelProperty()
-	r.EnrichResultsLocationURIProperty(locationWebURLCallback)
-}
-
 // SortResultsByLevel function sorts sarif results by level
 func (r Report) SortResultsByLevel() {
 

--- a/internal/sarif/sarif.go
+++ b/internal/sarif/sarif.go
@@ -288,7 +288,7 @@ func (r Report) EnrichResultsLevelProperty() {
 	}
 }
 
-func (r Report) EnrichResultsLocationURIProperty() {
+func (r Report) EnrichResultsLocationURIProperty(locationWebURLCB func(artifactLocation *sarif.Location) string) {
 	for _, result := range r.Runs[0].Results {
 		// if result location length is at least 1
 		if len(result.Locations) > 0 {
@@ -310,6 +310,8 @@ func (r Report) EnrichResultsLocationURIProperty() {
 						artifactLocation.Properties["URI"] = artifactLocation.Properties["URI"].(string)[1:]
 					}
 				}
+
+				artifactLocation.Properties["WebURL"] = locationWebURLCB(location)
 			}
 		}
 	}
@@ -317,11 +319,11 @@ func (r Report) EnrichResultsLocationURIProperty() {
 
 // EnrichResultsProperties function enriches sarif results properties with title, description, location and level values
 // for better html report representation
-func (r Report) EnrichResultsProperties() {
+func (r Report) EnrichResultsProperties(locationWebURLCB func(artifactLocation *sarif.Location) string) {
 	r.EnrichResultsTitleProperty()
 	r.EnrichResultsCodeFlowProperty()
 	r.EnrichResultsLevelProperty()
-	r.EnrichResultsLocationURIProperty()
+	r.EnrichResultsLocationURIProperty(locationWebURLCB)
 }
 
 // SortResultsByLevel function sorts sarif results by level

--- a/scripts/rules/requirements.txt
+++ b/scripts/rules/requirements.txt
@@ -1,4 +1,4 @@
 gitpython==3.1.41
-pyyaml==6.0
+pyyaml==5.3.1
 colorama==0.4.6
 tqdm==4.65.0

--- a/templates/tohtml/report.html
+++ b/templates/tohtml/report.html
@@ -225,8 +225,9 @@
 {{ $repo := .Metadata.RepositoryMetadata.RepositoryFullName }}
 {{ $branch := .Metadata.RepositoryMetadata.BranchName }}
 {{ $commit := .Metadata.RepositoryMetadata.CommitHash }}
-
-{{ $webURL := gitURLtoWebURL $repo }}
+{{ $branchURL := .Metadata.BranchURL }}
+{{ $commitURL := .Metadata.CommitURL }}
+{{ $webURL := .Metadata.WebURL }}
 
 <body>
   <!-- header goes here -->
@@ -265,8 +266,8 @@
         <p><b>Tool:</b> {{ .Metadata.ToolMetadata.Name }} {{if .Metadata.ToolMetadata.Version}}{{ .Metadata.ToolMetadata.Version }}{{end}}</p>
         {{if .Metadata.SourceFolder}}<p><b>Source:</b> {{ .Metadata.SourceFolder }}</p>{{end}}
         {{if $repo}}<p><b>Repository:</b> <a href="{{ $webURL }}">{{ $repo }}</a></p>{{end}}
-        {{if $branch}}<p><b>Branch:</b> {{if $webURL}}<a href="{{- $webURL -}}/tree/{{- $branch -}}">{{ $branch }}</a>{{else}}{{ $branch }}{{end}} </p>{{end}}
-        {{if $commit}}<p><b>Commit:</b> {{if $webURL}}<a href="{{- $webURL -}}/tree/{{- $commit -}}">{{ $commit }}</a>{{else}}{{ $commit }}{{end}} </p>{{end}}
+        {{if $branch}}<p><b>Branch:</b> {{if $branchURL}}<a href="{{- $branchURL -}}">{{ $branch }}</a>{{else}}{{ $branch }}{{end}} </p>{{end}}
+        {{if $commit}}<p><b>Commit:</b> {{if $commitURL}}<a href="{{- $commitURL -}}">{{ $commit }}</a>{{else}}{{ $commit }}{{end}} </p>{{end}}
         {{if .Metadata.RepositoryMetadata.Subfolder}}<p><b>Subfolder:</b> {{ .Metadata.RepositoryMetadata.Subfolder }} </p>{{end}}
       </div> 
     </div>

--- a/templates/tohtml/report.html
+++ b/templates/tohtml/report.html
@@ -294,7 +294,7 @@
               {{ $location := index .Locations 0}}
               {{ $locationURI := index $location.PhysicalLocation.ArtifactLocation.Properties "URI"}}
               {{ $locationStartLine := $location.PhysicalLocation.Region.StartLine }}
-              {{ $locationWebURL := index $location.PhysicalLocation.ArtifactLocation.Properties "WebURL"}}
+              {{ $locationWebURL := index $location.Properties "WebURL"}}
               <div class="issue-card__body__metadata__location">Location: <strong>{{if $locationWebURL}}<a href="{{- $locationWebURL -}}">{{$locationURI}} (line : {{$locationStartLine}})</a> {{else}} {{$locationURI}} (line : {{$locationStartLine}}){{end}}</strong></div>
             </div>
             <div class="issue-card__body__dataflows">
@@ -333,15 +333,18 @@
                         {{ $endLine := index .Location.PhysicalLocation.Region.Properties "EndLine" }}
                         {{ $startColumn := index .Location.PhysicalLocation.Region.Properties "StartColumn" }}
                         {{ $endColumn := index .Location.PhysicalLocation.Region.Properties "EndColumn" }}
+                        {{ $locationWebURL := index $location.Properties "WebURL"}}
                         {{/* */}}
 
                         <div class="issue-card__body__dataflows__codeline">
 
-                          {{if (and $webURL $commit)}}
-                            <span class="issue-card__body__dataflows__codeline__linecol"><a href="{{- $webURL -}}/blob/{{- $commit -}}/{{- $curUri -}}#L{{- $startLine -}}">{{$startLine}}:{{$startColumn}}</a></span>
+                          <span class="issue-card__body__dataflows__codeline__linecol">
+                          {{if $locationWebURL}}
+                            <a href="{{- $locationWebURL -}}">{{$startLine}}:{{$startColumn}}</a>
                           {{else}}
-                            <span class="issue-card__body__dataflows__codeline__linecol">{{$startLine}}:{{$startColumn}}</span>
+                            {{$startLine}}:{{$startColumn}}
                           {{end}}
+                          </span>
 
                           {{if $code}}
                           <div class="issue-card__body__dataflows__codeline__linecol__code">

--- a/templates/tohtml/report.html
+++ b/templates/tohtml/report.html
@@ -294,7 +294,8 @@
               {{ $location := index .Locations 0}}
               {{ $locationURI := index $location.PhysicalLocation.ArtifactLocation.Properties "URI"}}
               {{ $locationStartLine := $location.PhysicalLocation.Region.StartLine }}
-              <div class="issue-card__body__metadata__location">Location: <strong>{{if (and $webURL $commit)}}<a href="{{- $webURL -}}/blob/{{- $commit -}}/{{- $locationURI -}}#L{{- $locationStartLine -}}">{{$locationURI}} (line : {{$locationStartLine}})</a> {{else}} {{$locationURI}} (line : {{$locationStartLine}}){{end}}</strong></div>
+              {{ $locationWebURL := index $location.PhysicalLocation.ArtifactLocation.Properties "WebURL"}}
+              <div class="issue-card__body__metadata__location">Location: <strong>{{if $locationWebURL}}<a href="{{- $locationWebURL -}}">{{$locationURI}} (line : {{$locationStartLine}})</a> {{else}} {{$locationURI}} (line : {{$locationStartLine}}){{end}}</strong></div>
             </div>
             <div class="issue-card__body__dataflows">
               <header class="card__body__dataflows__header">


### PR DESCRIPTION
This MR introduced a callback functions for sarif module and to-html command.
sarif and git modules don't know anything about vcs web url structure. And this callback function allows to move this logic right inside main command. It also allowed us to remove web url logic from html templates. So html template are vcs agnostic now.

The functions that were introduced in to-html (buildWebURLToBranch, buildWebURLToCommit), runtime callback function (locationWebURLCallback) and existing (gitURLtoWebURL) should be used in future for vcs specific logic.

For now generic logic was introduced, that should work for most cloud vcs solutions (gitlab, github, bitbucket cloud).
