### PR TITLE
Add VCS Option and Enhance URL Generation Logic

### DIFF
--- a/cmd/to-html.go
+++ b/cmd/to-html.go
@@ -73,16 +73,18 @@ func buildGenericLocationURL(location *sarif.Location, url vcsurl.VCSURL, repoMe
 
 // buildBitbucketLocationURL constructs webURL for a report location for bitbucket
 func buildBitbucketLocationURL(location *sarif.Location, url vcsurl.VCSURL, repoMetadata *git.RepositoryMetadata) string {
+	// url example: https://bitbucket.onprem.example/projects/<project_name>/repos/<repo_name>/browse/<path>/<vuln.file>?at=<commit_hash>#<line>
 	// verify that location.PhysicalLocation.ArtifactLocation.Properties["URI"] is not nil
 	if location.PhysicalLocation.ArtifactLocation.Properties["URI"] == nil {
 		return ""
 	}
-	locationWebURL := filepath.Join(url.HTTPRepoLink, "src", *repoMetadata.CommitHash, location.PhysicalLocation.ArtifactLocation.Properties["URI"].(string))
+	locationWebURL := filepath.Join(url.HTTPRepoLink, "browse", location.PhysicalLocation.ArtifactLocation.Properties["URI"].(string))
+	locationWebURL += "?at=" + *repoMetadata.CommitHash
 	if location.PhysicalLocation.Region.StartLine != nil {
-		locationWebURL += "#lines-" + strconv.Itoa(*location.PhysicalLocation.Region.StartLine)
+		locationWebURL += "#" + strconv.Itoa(*location.PhysicalLocation.Region.StartLine)
 	}
 	if location.PhysicalLocation.Region.EndLine != nil && *location.PhysicalLocation.Region.EndLine != *location.PhysicalLocation.Region.StartLine {
-		locationWebURL += ":" + strconv.Itoa(*location.PhysicalLocation.Region.EndLine)
+		locationWebURL += "-" + strconv.Itoa(*location.PhysicalLocation.Region.EndLine)
 	}
 	return locationWebURL
 }

--- a/pkg/shared/vcsurl/vcsurl.go
+++ b/pkg/shared/vcsurl/vcsurl.go
@@ -231,10 +231,10 @@ func parseBitbucket(u VCSURL) (*VCSURL, error) {
 // buildBitbucketURLs sets the HTTP and SSH URLs for repositories.
 func buildBitbucketURLs(u *VCSURL, usePort bool, port string, isUserRepo bool) {
 	if isUserRepo {
-		u.HTTPRepoLink = fmt.Sprintf("https://%s/users/%s/repos/%s/browse", u.ParsedURL.Hostname(), u.Namespace, u.Repository)
+		u.HTTPRepoLink = fmt.Sprintf("https://%s/users/%s/repos/%s", u.ParsedURL.Hostname(), u.Namespace, u.Repository)
 		u.SSHRepoLink = fmt.Sprintf("ssh://git@%s:7989/~%s/%s.git", u.ParsedURL.Hostname(), u.Namespace, u.Repository)
 	} else {
-		u.HTTPRepoLink = fmt.Sprintf("https://%s/scm/%s/%s.git", u.ParsedURL.Hostname(), u.Namespace, u.Repository)
+		u.HTTPRepoLink = fmt.Sprintf("https://%s/projects/%s/repos/%s", u.ParsedURL.Hostname(), u.Namespace, u.Repository)
 		u.SSHRepoLink = fmt.Sprintf("ssh://git@%s:7989/%s/%s.git", u.ParsedURL.Hostname(), u.Namespace, u.Repository)
 	}
 

--- a/pkg/shared/vcsurl/vcsurl_test.go
+++ b/pkg/shared/vcsurl/vcsurl_test.go
@@ -186,13 +186,13 @@ func TestParseBitbucketAPIV1(t *testing.T) {
 		},
 		{
 			name:  "Bitbucket HTTPS APIv1 repo URL with Username",
-			input: "https://bitbucket.org/users/scanio-bot/repos/scanio-test-repository/browse",
+			input: "https://bitbucket.org/users/scanio-bot/repos/scanio-test-repository/",
 			expected: VCSURL{
 				Namespace:     "scanio-bot",
 				Repository:    "scanio-test-repository",
-				HTTPRepoLink:  "https://bitbucket.org/users/scanio-bot/repos/scanio-test-repository/browse",
+				HTTPRepoLink:  "https://bitbucket.org/users/scanio-bot/repos/scanio-test-repository",
 				SSHRepoLink:   "ssh://git@bitbucket.org:7989/~scanio-bot/scanio-test-repository.git",
-				Raw:           "https://bitbucket.org/users/scanio-bot/repos/scanio-test-repository/browse",
+				Raw:           "https://bitbucket.org/users/scanio-bot/repos/scanio-test-repository/",
 				PullRequestId: "",
 				VCSType:       Bitbucket,
 			},
@@ -203,7 +203,7 @@ func TestParseBitbucketAPIV1(t *testing.T) {
 			expected: VCSURL{
 				Namespace:     "scanio-project",
 				Repository:    "scanio-test-repository",
-				HTTPRepoLink:  "https://bitbucket.org/scm/scanio-project/scanio-test-repository.git",
+				HTTPRepoLink:  "https://bitbucket.org/projects/scanio-project/repos/scanio-test-repository",
 				SSHRepoLink:   "ssh://git@bitbucket.org:7989/scanio-project/scanio-test-repository.git",
 				Raw:           "https://bitbucket.org/projects/scanio-project/repos/scanio-test-repository/pull-requests/1",
 				PullRequestId: "1",
@@ -216,7 +216,7 @@ func TestParseBitbucketAPIV1(t *testing.T) {
 			expected: VCSURL{
 				Namespace:     "scanio-project",
 				Repository:    "scanio-test-repository",
-				HTTPRepoLink:  "https://bitbucket.org/scm/scanio-project/scanio-test-repository.git",
+				HTTPRepoLink:  "https://bitbucket.org/projects/scanio-project/repos/scanio-test-repository",
 				SSHRepoLink:   "ssh://git@bitbucket.org:7989/scanio-project/scanio-test-repository.git",
 				Raw:           "https://bitbucket.org/projects/scanio-project/repos/scanio-test-repository/browse",
 				PullRequestId: "",
@@ -243,7 +243,7 @@ func TestParseBitbucketAPIV1(t *testing.T) {
 			expected: VCSURL{
 				Namespace:     "scanio-project",
 				Repository:    "scanio-test-repository",
-				HTTPRepoLink:  "https://bitbucket.org/scm/scanio-project/scanio-test-repository.git",
+				HTTPRepoLink:  "https://bitbucket.org/projects/scanio-project/repos/scanio-test-repository",
 				SSHRepoLink:   "ssh://git@bitbucket.org:7989/scanio-project/scanio-test-repository.git",
 				Raw:           "https://bitbucket.org/scm/scanio-project/scanio-test-repository.git",
 				PullRequestId: "",
@@ -269,7 +269,7 @@ func TestParseBitbucketAPIV1(t *testing.T) {
 			expected: VCSURL{
 				Namespace:     "scanio-project",
 				Repository:    "scanio-test-repository",
-				HTTPRepoLink:  "https://bitbucket.org/scm/scanio-project/scanio-test-repository.git",
+				HTTPRepoLink:  "https://bitbucket.org/projects/scanio-project/repos/scanio-test-repository",
 				SSHRepoLink:   "ssh://git@bitbucket.org:7989/scanio-project/scanio-test-repository.git",
 				Raw:           "ssh://git@bitbucket.org/scanio-project/scanio-test-repository.git",
 				PullRequestId: "",
@@ -282,7 +282,7 @@ func TestParseBitbucketAPIV1(t *testing.T) {
 			expected: VCSURL{
 				Namespace:     "scanio-project",
 				Repository:    "scanio-test-repository",
-				HTTPRepoLink:  "https://bitbucket.org/scm/scanio-project/scanio-test-repository.git",
+				HTTPRepoLink:  "https://bitbucket.org/projects/scanio-project/repos/scanio-test-repository",
 				SSHRepoLink:   "ssh://git@bitbucket.org:22/scanio-project/scanio-test-repository.git",
 				Raw:           "ssh://git@bitbucket.org:22/scanio-project/scanio-test-repository.git",
 				PullRequestId: "",

--- a/templates/tohtml/report.html
+++ b/templates/tohtml/report.html
@@ -267,7 +267,7 @@
         {{if .Metadata.SourceFolder}}<p><b>Source:</b> {{ .Metadata.SourceFolder }}</p>{{end}}
         {{if $repo}}<p><b>Repository:</b> <a href="{{ $webURL }}">{{ $repo }}</a></p>{{end}}
         {{if $branch}}<p><b>Branch:</b> {{if $branchURL}}<a href="{{- $branchURL -}}">{{ $branch }}</a>{{else}}{{ $branch }}{{end}} </p>{{end}}
-        {{if $commit}}<p><b>Commit:</b> {{if $commitURL}}<a href="{{- $commitURL -}}">{{ $commit }}</a>{{else}}{{ $commit }}{{end}} </p>{{end}}
+        {{if $commit}}<p><b>Latest Commit:</b> {{if $commitURL}}<a href="{{- $commitURL -}}">{{ $commit }}</a>{{else}}{{ $commit }}{{end}} </p>{{end}}
         {{if .Metadata.RepositoryMetadata.Subfolder}}<p><b>Subfolder:</b> {{ .Metadata.RepositoryMetadata.Subfolder }} </p>{{end}}
       </div> 
     </div>


### PR DESCRIPTION
- Added the `VCS` field to the `ToHTMLOptions` struct to specify the version control system type.
- Implemented VCS-specific logic for generating web URLs for branches and commits.
- Enhanced the URL generation logic to handle both generic (cover github and gitlab) and Bitbucket-specific URLs.
- Updated the command-line flags to include the `VCS` option.

Example of usage
```
scanio to-html --input /data/scanio-report-semgrep-2024-10-21T04\:02\:28Z.sarif --output report.html -s /data --vcs github
```

issue: #96