### PR TITLE
shikari/html template improve

### DIFF
--- a/cmd/to-html.go
+++ b/cmd/to-html.go
@@ -73,16 +73,18 @@ func buildGenericLocationURL(location *sarif.Location, url vcsurl.VCSURL, repoMe
 
 // buildBitbucketLocationURL constructs webURL for a report location for bitbucket
 func buildBitbucketLocationURL(location *sarif.Location, url vcsurl.VCSURL, repoMetadata *git.RepositoryMetadata) string {
+	// url example: https://bitbucket.onprem.example/projects/<project_name>/repos/<repo_name>/browse/<path>/<vuln.file>?at=<commit_hash>#<line>
 	// verify that location.PhysicalLocation.ArtifactLocation.Properties["URI"] is not nil
 	if location.PhysicalLocation.ArtifactLocation.Properties["URI"] == nil {
 		return ""
 	}
-	locationWebURL := filepath.Join(url.HTTPRepoLink, "src", *repoMetadata.CommitHash, location.PhysicalLocation.ArtifactLocation.Properties["URI"].(string))
+	locationWebURL := filepath.Join(url.HTTPRepoLink, "browse", location.PhysicalLocation.ArtifactLocation.Properties["URI"].(string))
+	locationWebURL += "?at=" + *repoMetadata.CommitHash
 	if location.PhysicalLocation.Region.StartLine != nil {
-		locationWebURL += "#lines-" + strconv.Itoa(*location.PhysicalLocation.Region.StartLine)
+		locationWebURL += "#" + strconv.Itoa(*location.PhysicalLocation.Region.StartLine)
 	}
 	if location.PhysicalLocation.Region.EndLine != nil && *location.PhysicalLocation.Region.EndLine != *location.PhysicalLocation.Region.StartLine {
-		locationWebURL += ":" + strconv.Itoa(*location.PhysicalLocation.Region.EndLine)
+		locationWebURL += "-" + strconv.Itoa(*location.PhysicalLocation.Region.EndLine)
 	}
 	return locationWebURL
 }

--- a/pkg/shared/vcsurl/vcsurl.go
+++ b/pkg/shared/vcsurl/vcsurl.go
@@ -231,10 +231,10 @@ func parseBitbucket(u VCSURL) (*VCSURL, error) {
 // buildBitbucketURLs sets the HTTP and SSH URLs for repositories.
 func buildBitbucketURLs(u *VCSURL, usePort bool, port string, isUserRepo bool) {
 	if isUserRepo {
-		u.HTTPRepoLink = fmt.Sprintf("https://%s/users/%s/repos/%s/browse", u.ParsedURL.Hostname(), u.Namespace, u.Repository)
+		u.HTTPRepoLink = fmt.Sprintf("https://%s/users/%s/repos/%s", u.ParsedURL.Hostname(), u.Namespace, u.Repository)
 		u.SSHRepoLink = fmt.Sprintf("ssh://git@%s:7989/~%s/%s.git", u.ParsedURL.Hostname(), u.Namespace, u.Repository)
 	} else {
-		u.HTTPRepoLink = fmt.Sprintf("https://%s/scm/%s/%s.git", u.ParsedURL.Hostname(), u.Namespace, u.Repository)
+		u.HTTPRepoLink = fmt.Sprintf("https://%s/projects/%s/repos/%s", u.ParsedURL.Hostname(), u.Namespace, u.Repository)
 		u.SSHRepoLink = fmt.Sprintf("ssh://git@%s:7989/%s/%s.git", u.ParsedURL.Hostname(), u.Namespace, u.Repository)
 	}
 

--- a/pkg/shared/vcsurl/vcsurl_test.go
+++ b/pkg/shared/vcsurl/vcsurl_test.go
@@ -186,13 +186,13 @@ func TestParseBitbucketAPIV1(t *testing.T) {
 		},
 		{
 			name:  "Bitbucket HTTPS APIv1 repo URL with Username",
-			input: "https://bitbucket.org/users/scanio-bot/repos/scanio-test-repository/browse",
+			input: "https://bitbucket.org/users/scanio-bot/repos/scanio-test-repository/",
 			expected: VCSURL{
 				Namespace:     "scanio-bot",
 				Repository:    "scanio-test-repository",
-				HTTPRepoLink:  "https://bitbucket.org/users/scanio-bot/repos/scanio-test-repository/browse",
+				HTTPRepoLink:  "https://bitbucket.org/users/scanio-bot/repos/scanio-test-repository",
 				SSHRepoLink:   "ssh://git@bitbucket.org:7989/~scanio-bot/scanio-test-repository.git",
-				Raw:           "https://bitbucket.org/users/scanio-bot/repos/scanio-test-repository/browse",
+				Raw:           "https://bitbucket.org/users/scanio-bot/repos/scanio-test-repository/",
 				PullRequestId: "",
 				VCSType:       Bitbucket,
 			},
@@ -203,7 +203,7 @@ func TestParseBitbucketAPIV1(t *testing.T) {
 			expected: VCSURL{
 				Namespace:     "scanio-project",
 				Repository:    "scanio-test-repository",
-				HTTPRepoLink:  "https://bitbucket.org/scm/scanio-project/scanio-test-repository.git",
+				HTTPRepoLink:  "https://bitbucket.org/projects/scanio-project/repos/scanio-test-repository",
 				SSHRepoLink:   "ssh://git@bitbucket.org:7989/scanio-project/scanio-test-repository.git",
 				Raw:           "https://bitbucket.org/projects/scanio-project/repos/scanio-test-repository/pull-requests/1",
 				PullRequestId: "1",
@@ -216,7 +216,7 @@ func TestParseBitbucketAPIV1(t *testing.T) {
 			expected: VCSURL{
 				Namespace:     "scanio-project",
 				Repository:    "scanio-test-repository",
-				HTTPRepoLink:  "https://bitbucket.org/scm/scanio-project/scanio-test-repository.git",
+				HTTPRepoLink:  "https://bitbucket.org/projects/scanio-project/repos/scanio-test-repository",
 				SSHRepoLink:   "ssh://git@bitbucket.org:7989/scanio-project/scanio-test-repository.git",
 				Raw:           "https://bitbucket.org/projects/scanio-project/repos/scanio-test-repository/browse",
 				PullRequestId: "",
@@ -243,7 +243,7 @@ func TestParseBitbucketAPIV1(t *testing.T) {
 			expected: VCSURL{
 				Namespace:     "scanio-project",
 				Repository:    "scanio-test-repository",
-				HTTPRepoLink:  "https://bitbucket.org/scm/scanio-project/scanio-test-repository.git",
+				HTTPRepoLink:  "https://bitbucket.org/projects/scanio-project/repos/scanio-test-repository",
 				SSHRepoLink:   "ssh://git@bitbucket.org:7989/scanio-project/scanio-test-repository.git",
 				Raw:           "https://bitbucket.org/scm/scanio-project/scanio-test-repository.git",
 				PullRequestId: "",
@@ -269,7 +269,7 @@ func TestParseBitbucketAPIV1(t *testing.T) {
 			expected: VCSURL{
 				Namespace:     "scanio-project",
 				Repository:    "scanio-test-repository",
-				HTTPRepoLink:  "https://bitbucket.org/scm/scanio-project/scanio-test-repository.git",
+				HTTPRepoLink:  "https://bitbucket.org/projects/scanio-project/repos/scanio-test-repository",
 				SSHRepoLink:   "ssh://git@bitbucket.org:7989/scanio-project/scanio-test-repository.git",
 				Raw:           "ssh://git@bitbucket.org/scanio-project/scanio-test-repository.git",
 				PullRequestId: "",
@@ -282,7 +282,7 @@ func TestParseBitbucketAPIV1(t *testing.T) {
 			expected: VCSURL{
 				Namespace:     "scanio-project",
 				Repository:    "scanio-test-repository",
-				HTTPRepoLink:  "https://bitbucket.org/scm/scanio-project/scanio-test-repository.git",
+				HTTPRepoLink:  "https://bitbucket.org/projects/scanio-project/repos/scanio-test-repository",
 				SSHRepoLink:   "ssh://git@bitbucket.org:22/scanio-project/scanio-test-repository.git",
 				Raw:           "ssh://git@bitbucket.org:22/scanio-project/scanio-test-repository.git",
 				PullRequestId: "",

--- a/plugins/trufflehog3/internal/report.go
+++ b/plugins/trufflehog3/internal/report.go
@@ -156,9 +156,9 @@ func JsonToSarifReport(filePath string) (string, error) {
 	}
 	defer func() { _ = file.Close() }()
 	if err := reportSarif.PrettyWrite(file); err != nil {
-		return filePath, err
+		return outputFilePath, err
 	}
-	return filePath, nil
+	return outputFilePath, nil
 }
 
 func toSarifErrorLevel(severity string) string {

--- a/plugins/trufflehog3/trufflehog3.go
+++ b/plugins/trufflehog3/trufflehog3.go
@@ -145,8 +145,8 @@ func (g *ScannerTrufflehog3) Scan(args shared.ScannerScanRequest) (shared.Scanne
 		g.logger.Info("Report conversion finished", "newFormat", originalFormat, "convertedPath", result.ResultsPath)
 	}
 
-	g.logger.Info("Result is saved to", "path to a result file", args.ResultsPath)
-	g.logger.Debug("Debug info", "project", args.TargetPath, "config", args.ConfigPath, "resultsFile", args.ResultsPath, "cmd", cmd.Args)
+	g.logger.Info("Result is saved to", "path to a result file", result.ResultsPath)
+	g.logger.Debug("Debug info", "project", args.TargetPath, "config", args.ConfigPath, "resultsFile", result.ResultsPath, "cmd", cmd.Args)
 	return result, nil
 }
 

--- a/plugins/trufflehog3/validation.go
+++ b/plugins/trufflehog3/validation.go
@@ -14,11 +14,11 @@ func (g *ScannerTrufflehog3) CheckReportFormat(args *shared.ScannerScanRequest) 
 	if originalFormat != "" {
 		switch originalFormat {
 		case "sarif":
-			g.logger.Warn("SARIF report format requested. Default scanner JSON report will be converted.")
+			g.logger.Warn("SARIF report format requested. Default scanner JSON report will be converted")
 			reportFormat = "json"
 			needsConversion = true
 		case "markdown":
-			g.logger.Warn("Human-readable markdown report format requested. Default scanner JSON report will be converted.")
+			g.logger.Warn("Human-readable markdown report format requested. Default scanner JSON report will be converted")
 			reportFormat = "json"
 			needsConversion = true
 		default:

--- a/templates/tohtml/report.html
+++ b/templates/tohtml/report.html
@@ -391,16 +391,6 @@
       opacity: 1;
     }
 
-    button {
-      position: fixed;
-      top: 16px;
-      right: 16px;
-      z-index: 100;
-      background-color: transparent;
-      border: none;
-      cursor: pointer;
-    }
-
     .fancy-footer {
       background-color: var(--footer-bg);
       color: var(--footer-text);
@@ -471,6 +461,58 @@
       font-size: 14px;
       margin: 0;
     }
+
+    .scroll-up-button {
+      position: fixed;
+      bottom: 20px; 
+      right: 30px;  
+      width: 40px;
+      height: 40px;
+      border: none;
+      visibility: hidden;
+      opacity: 0; 
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      transition: visibility 0.5s ease, opacity 0.5s ease-in-out, transform 0.5s ease-in-out;
+      z-index: 1000;
+      background-color: transparent; 
+    }
+
+    .scroll-up-button svg {
+      width: 100%;
+      height: 100%;
+      fill: currentColor;
+      transition: fill 0.3s ease;
+    }
+
+    body.light-mode .scroll-up-button svg {
+      color: #007bff; 
+    }
+
+    body.dark-mode .scroll-up-button svg {
+      color: #31bc81; 
+    }
+
+    .scroll-up-button:hover {
+      transform: translateY(-3px);
+    }
+
+    .scroll-up-button:active {
+      transform: translateY(0);
+    }
+
+    .scroll-up-button.show {
+      visibility: visible; 
+      opacity: 1; 
+    }
+
+    .scroll-up-button.hide {
+      visibility: hidden; 
+      opacity: 0; 
+      pointer-events: none;
+    }
+
   </style>
 
 </head>
@@ -663,89 +705,117 @@
   </div>
 
   <script>
-    function setTheme(mode) {
+    document.addEventListener("DOMContentLoaded", function () {
+      const scrollUpButton = document.getElementById("scrollUpButton");
+      const thresholdPercentage = 0.2; 
+
+      window.addEventListener("scroll", function () {
+        const scrollHeight = document.documentElement.scrollHeight;
+        const scrollRatio = window.scrollY / scrollHeight;
+
+        if (scrollRatio > thresholdPercentage) {
+          scrollUpButton.classList.add("show");
+        } else {
+          scrollUpButton.classList.remove("show");
+        }
+      });
+
+      scrollUpButton.addEventListener("click", function () {
+        window.scrollTo({
+          top: 0,
+          behavior: "smooth"
+        });
+      });
+
       const themeSwitcher = document.getElementById("theme-switcher-grid");
 
-      if (mode === "dark") {
-        document.body.classList.add("dark-mode");
-        themeSwitcher.classList.add("dark-mode");
-        document.body.classList.remove("light-mode");
-      } else {
-        document.body.classList.add("light-mode");
-        document.body.classList.remove("dark-mode");
-        themeSwitcher.classList.remove("dark-mode");
+      function setTheme(mode) {
+        if (mode === "dark") {
+          document.body.classList.add("dark-mode");
+          document.body.classList.remove("light-mode");
+          themeSwitcher.classList.add("dark-mode");
+        } else {
+          document.body.classList.add("light-mode");
+          document.body.classList.remove("dark-mode");
+          themeSwitcher.classList.remove("dark-mode");
+        }
       }
-    }
 
-    function getSystemThemePreference() {
-      return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? "dark" : "light";
-    }
-
-    function getSavedTheme() {
-      return localStorage.getItem("theme");
-    }
-
-    function saveThemePreference(mode) {
-      localStorage.setItem("theme", mode);
-    }
-
-    function initializeTheme() {
-      const savedTheme = getSavedTheme();
-      const systemTheme = getSystemThemePreference();
-
-      if (savedTheme) {
-        setTheme(savedTheme);
-      } else {
-        setTheme(systemTheme);
+      function getSystemThemePreference() {
+        return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? "dark" : "light";
       }
-    }
 
-    document.getElementById("theme-switcher-grid").addEventListener("click", function () {
-      const isDarkMode = document.body.classList.contains("dark-mode");
+      function getSavedTheme() {
+        return localStorage.getItem("theme");
+      }
 
-      if (isDarkMode) {
-        setTheme("light");
-        saveThemePreference("light");
-      } else {
-        setTheme("dark");
-        saveThemePreference("dark");
+      function saveThemePreference(mode) {
+        localStorage.setItem("theme", mode);
+      }
+
+      function initializeTheme() {
+        const savedTheme = getSavedTheme();
+        const systemTheme = getSystemThemePreference();
+
+        if (savedTheme) {
+          setTheme(savedTheme);
+        } else {
+          setTheme(systemTheme);
+        }
+      }
+
+      themeSwitcher.addEventListener("click", function () {
+        const isDarkMode = document.body.classList.contains("dark-mode");
+
+        if (isDarkMode) {
+          setTheme("light");
+          saveThemePreference("light");
+        } else {
+          setTheme("dark");
+          saveThemePreference("dark");
+        }
+      });
+
+      initializeTheme();
+
+      window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', e => {
+        const newSystemTheme = e.matches ? "dark" : "light";
+        const savedTheme = getSavedTheme();
+
+        if (!savedTheme) {
+          setTheme(newSystemTheme);
+        }
+      });
+
+      // Dataflow update logic (if necessary, based on your previous requirements)
+      var s = null;
+      function updateSelectedDataflow(event, dataflowId) {
+        console.log(event);
+        s = event;
+        const selectedElement = event.target.closest('header').querySelector('.selected-dataflow-id');
+        if (selectedElement) {
+          selectedElement.classList.remove('selected-dataflow-id');
+        }
+        event.target.classList.add('selected-dataflow-id');
+
+        const dataflowContainer = event.target.closest('.issue-card__body__dataflows');
+        const currentDataflowElement = dataflowContainer.querySelector('.selected-dataflow');
+        if (currentDataflowElement) {
+          currentDataflowElement.classList.remove('selected-dataflow');
+        }
+        const selectedDataflowElement = dataflowContainer.querySelector('.issue-card__body__dataflow--' + dataflowId);
+        if (selectedDataflowElement) {
+          selectedDataflowElement.classList.add('selected-dataflow');
+        }
       }
     });
-
-    initializeTheme();
-
-    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', e => {
-      const newSystemTheme = e.matches ? "dark" : "light";
-      const savedTheme = getSavedTheme();
-
-      if (!savedTheme) {
-        setTheme(newSystemTheme);
-      }
-    });
-
-    var s = null;
-
-    function updateSelectedDataflow(event, dataflowId) {
-      console.log(event);
-      s = event;
-      const selectedElement = event.target.closest('header').querySelector('.selected-dataflow-id');
-      if (selectedElement) {
-        selectedElement.classList.remove('selected-dataflow-id');
-      }
-      event.target.classList.add('selected-dataflow-id');
-
-      // find closest div with class 'issue-card__body__dataflows'
-      const dataflowContainer = event.target.closest('.issue-card__body__dataflows');
-      const currentDataflowElement = dataflowContainer.querySelector('.selected-dataflow')
-      if (currentDataflowElement) {
-        currentDataflowElement.classList.remove('selected-dataflow');
-      }
-      const selectedDataflowElement = dataflowContainer.querySelector('.issue-card__body__dataflow--' + dataflowId);
-      if (selectedDataflowElement) {
-        selectedDataflowElement.classList.add('selected-dataflow');
-      }
-    }
   </script>
+<button id="scrollUpButton" class="scroll-up-button" aria-label="Scroll to top">
+  <!-- svg source https://uxwing.com/line-angle-up-icon/ -->
+  <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 122.88 66.91" style="enable-background:new 0 0 122.88 66.91" xml:space="preserve">
+    <g><path d="M11.68,64.96c-2.72,2.65-7.08,2.59-9.73-0.14c-2.65-2.72-2.59-7.08,0.13-9.73L56.87,1.97l4.8,4.93l-4.81-4.95 c2.74-2.65,7.1-2.58,9.76,0.15c0.08,0.08,0.15,0.16,0.23,0.24L120.8,55.1c2.72,2.65,2.78,7.01,0.13,9.73 c-2.65,2.72-7,2.78-9.73,0.14L61.65,16.5L11.68,64.96L11.68,64.96z"/></g>
+  </svg>
+</button>
 </body>
 <footer class="fancy-footer">
   <div class="footer-container">

--- a/templates/tohtml/report.html
+++ b/templates/tohtml/report.html
@@ -9,16 +9,32 @@
   <title>{{ .Metadata.Title }}</title>
   <base target="_blank">
 
-  <!-- inline css goes here -->
   <style type="text/css">
+    :root {
+      --bg-color-light: #dad7cd;
+      --bg-color-dark: #0d1117;
+      --border-color-light: #1c2135;
+      --border-color-dark: #f0f0e8;
+      --sun-color: #fabc1c;
+      --moon-color: #fffdf2;
+      --day-bg-color: #0dbdf6;
+      --night-bg-color: #272a30;
+      --cloud-color: #fffdf2;
+      --star-color: #fffdf2;
+    }
 
     body {
-      font-family: system-ui, Helvetica, sans-serif;
+      font-family: 'Open Sans', system-ui, Helvetica, sans-serif;
       margin: 0;
       padding: 0;
       display: flex;
       flex-direction: column;
-      background-color: #F5F5F5;
+      transition: background-color 0.5s ease-in-out, color 0.5s ease-in-out;
+    }
+
+    body.dark-mode {
+      background-color: var(--bg-color-dark);
+      color: #F1F1F1;
     }
 
     .main-body {
@@ -44,13 +60,18 @@
 
     .issue-card {
       left: 0;
-      /* position: absolute; */
       top: 10px;
-      padding: 16px 8px;
-      border-radius: 8px 8px 0px 0px;
+      padding: 24px 16px;
+      border-radius: 8px;
       border: 2px solid;
-      margin-bottom: 32px;
+      margin-bottom: 40px;
       background-color: #F3F3F3;
+    }
+
+
+    body.dark-mode .issue-card {
+      background-color: #151b23f2;
+      border-color: #8a939f;
     }
 
     .severity--error {
@@ -66,15 +87,15 @@
     }
 
     .severity-icon {
-      width: 32px; /* Width of the SVG image */
-      height: 32px; /* Height of the SVG image */
+      width: 32px; 
+      height: 32px; 
       display: inline-block;
       margin-right: 8px;
     }
 
     .severity-icon--small {
-      width: 24px; /* Width of the SVG image */
-      height: 24px; /* Height of the SVG image */
+      width: 24px; 
+      height: 24px; 
       display: inline-block;
       margin-right: 6px;
     }
@@ -100,21 +121,32 @@
     .issue-card__body__metadata {
       padding: 8px 8px;
       border: 2px solid #d3d3d9;
-      border-radius: 2px;
+      border-radius: 8px;
       margin-bottom: 8px;
       overflow: auto;
     }
 
+    body.dark-mode .issue-card__body__metadata {
+      border-color: #8a939f;
+      background-color: var(--bg-color-dark);
+    }
+
     .issue-card__body__dataflows__filename {
       padding:4px 8px;
-      border:1px solid #eee;
-      font-size:12px;
+      border:1px solid #d3d3d9;
+      border-radius: 8px;
+      font-size:14px;
+    }
+
+    body.dark-mode .issue-card__body__dataflows__filename {
+      border-color: #8a939f;
+      background-color: var(--bg-color-dark);
     }
 
     .issue-card__body__dataflows__codeline {
       padding:4px 8px;
       font-family: monospace;
-      font-size:12px;
+      font-size:14px;
       display: flex;
     }
 
@@ -129,18 +161,22 @@
     }
 
     .issue-card__body__metadata__location {
-      font-size: 12px;
+      font-size: 14px;
     }
 
     .issue-card__body__dataflow-id {
       display: inline-block;
-      width: 16px; /* Adjust as needed */
-      height: 16px; /* Make sure width and height are equal */
-      border: 2px solid #d3d3d9; /* Adjust border thickness and color as needed */
-      border-radius: 50%; /* This makes the border round */
-      text-align: center; /* Centers the text horizontally */
-      line-height: 16px; /* Adjust this to be equal to the height to center the text vertically */
-      font-size: 12px; /* Adjust text size as needed */
+      width: 16px; 
+      height: 16px; 
+      border: 2px solid #d3d3d9; 
+      border-radius: 50%;
+      text-align: center; 
+      line-height: 1.5;
+      font-size: 14px;
+    }
+
+    body.dark-mode .issue-card__body__dataflow-id {
+      background-color: #8a939f;
     }
 
     .card__body__dataflows__header {
@@ -152,7 +188,7 @@
     }
 
     .selected-dataflow-id {
-      background-color:#6c249c;
+      background-color:#31bc81;
       color: #ffffff;
     }
 
@@ -169,18 +205,25 @@
       background-color: rgba(0,0,0,.1);
     }
 
+    body.dark-mode .dataflow-code-highlighted {
+      background-color: #386641
+    }
+
     .header-container {
-      background-color: #6c249c;
-      color: #eee;
+      justify-content: space-between;
+      align-items: center;
+      background-color: #32bc81;
+      color: #000;
       padding: 8px;
     }
 
     .header-container__metadata {
+      background-color: rgba(0, 0, 0, 0.05);
+      padding: 12px;
+      border-radius: 4px;
       float: right;
       text-align: left;
-      font-size: 12px;
-      /* margin-right: 16px; */
-      /* margin-left: auto; */
+      font-size: 14px;
     }
 
     .header-container__metadata p {
@@ -188,11 +231,16 @@
     }
 
     .header-container__metadata p a {
-      color: #eee;
+      color: #334D82; 
     }
 
     .issue-card__body__metadata__location a, .issue-card__body__dataflows__codeline__linecol a {
-      color: #000;
+      color: #4a90e2; 
+    }
+
+    body.dark-mode .issue-card__body__metadata__location a, 
+    body.dark-mode .issue-card__body__dataflows__codeline__linecol a {
+      color: #4a90e2; 
     }
 
     .header-container__logo {
@@ -207,15 +255,127 @@
       margin: 0 auto;
       justify-content: space-between;
       align-items: center;
+      flex-wrap: wrap;
     }
 
     .header-container__issues-breakdown {
       /* margin: auto; */
-      font-size: 16px;
+      font-size: 14px;
+      background-color: rgba(0, 0, 0, 0.05);
+      padding: 12px;
+      border-radius: 4px;
+      float: right;
+      text-align: left;
     }
 
     .header-container__issues-breakdown__table__entry {
       display: flex;
+      align-items: center; 
+      gap: 8px; 
+      margin-bottom: 2px;
+    }
+
+    .theme-switcher-grid {
+      position: fixed;
+      top: 16px;
+      right: 16px;
+      z-index: 100;
+      display: grid;
+      grid-template-columns: repeat(54, 1px);
+      grid-template-rows: repeat(24, 1px);
+      background-color: var(--day-bg-color);
+      border-radius: 49px;
+      border: 2px solid var(--border-color-light);
+      cursor: pointer;
+      transition: background-color 0.5s ease, border-color 0.5s ease;
+      padding: 0;
+      appearance: none;
+    }
+
+    .theme-switcher-grid.night-theme {
+      background-color: var(--night-bg-color);
+      border-color: var(--border-color-dark);
+    }
+
+    .sun {
+      background-color: var(--sun-color);
+      grid-column: 3 / 23;
+      grid-row: 3 / 23;
+      border-radius: 50%;
+      transition: grid-column 0.5s ease, background-color 0.5s ease;
+      height: 20px;
+    }
+
+    .theme-switcher-grid.night-theme .sun {
+      grid-column: 33 / 53;
+      background-color: var(--moon-color);
+    }
+
+    .moon-overlay {
+      position: absolute;
+      border-radius: 50%;
+      transition: left 0.5s ease, background-color 0.5s ease;
+      z-index: 1;
+      background-color: var(--day-bg-color);
+    }
+
+    .theme-switcher-grid.night-theme .moon-overlay {
+      display: block;
+      left: calc(28 / 54 * 100%);
+      top: calc(4 / 29 * 100%);
+      width: 18px;
+      height: 18px;
+      background-color: var(--night-bg-color);
+    }
+
+    .cloud-ball {
+      background-color: var(--cloud-color);
+      border-radius: 50%;
+      width: 9px;
+      height: 9px;
+      position: absolute;
+      transition: all 0.5s ease;
+      z-index: 2;
+    }
+
+    #ball1 { top: calc((8 / 24) * 100%); left: calc((12 / 54) * 100%); }
+    #ball2 { top: calc((8 / 24) * 100%); left: calc((17 / 54) * 100%); }
+    #ball3 { top: calc((8 / 24) * 100%); left: calc((22 / 54) * 100%); }
+    #ball4 { top: calc((6 / 24) * 100%); left: calc((17 / 54) * 100%); }
+
+    .theme-switcher-grid.night-theme #ball1 { top: calc((17 / 24) * 100%); left: calc((17 / 54) * 100%); width: 2px; height: 2px; }
+    .theme-switcher-grid.night-theme #ball2 { top: calc((4 / 24) * 100%); left: calc((23 / 54) * 100%); width: 2px; height: 2px; }
+    .theme-switcher-grid.night-theme #ball3 { top: calc((11 / 24) * 100%); left: calc((30 / 54) * 100%); width: 2px; height: 2px; }
+    .theme-switcher-grid.night-theme #ball4 { top: calc((6 / 24) * 100%); left: calc((35 / 54) * 100%); width: 2px; height: 2px; }
+
+    .star { 
+      background-color: var(--star-color); 
+      width: 1px; 
+      height: 1px; 
+      position: absolute; 
+      opacity: 0; 
+      transition: opacity 0.5s ease, top 0.5s ease, left 0.5s ease;
+    }
+    #star1 { top: calc((19 / 24) * 100%); left: calc((11 / 54) * 100%); }
+    #star2 { top: calc((5 / 24) * 100%); left: calc((10 / 54) * 100%); }
+    #star3 { top: calc((11 / 24) * 100%); left: calc((17 / 54) * 100%); }
+    #star4 { top: calc((18 / 24) * 100%); left: calc((25 / 54) * 100%); }
+
+    .theme-switcher-grid.night-theme #star1,
+    .theme-switcher-grid.night-theme #star2,
+    .theme-switcher-grid.night-theme #star3,
+    .theme-switcher-grid.night-theme #star4 {
+      opacity: 1;
+    }
+
+    button {
+      position: fixed;
+      top: 16px;
+      right: 16px;
+      z-index: 100;
+      background-color: transparent;
+      border: none;
+      cursor: pointer;
     }
 
   </style>
@@ -230,7 +390,6 @@
 {{ $webURL := .Metadata.WebURL }}
 
 <body>
-  <!-- header goes here -->
   <header class="header-container">
     <div class="header-container-centering">
       <div class="header-container__logo">
@@ -244,7 +403,7 @@
       </div>
 
       <div class="header-container__issues-breakdown">
-        <div class="header-container__issues-breakdown__total">There are {{index .Metadata.SeverityInfo "total"}} issues</div>
+        <div class="header-container__issues-breakdown__total">There are {{index .Metadata.SeverityInfo "total"}} issues:</div>
         <div class="header-container__issues-breakdown__table">
           <div class="header-container__issues-breakdown__table__entry">
             <div class="severity-icon--small severity-icon--error"></div>
@@ -270,7 +429,40 @@
         {{if $commit}}<p><b>Latest Commit:</b> {{if $commitURL}}<a href="{{- $commitURL -}}">{{ $commit }}</a>{{else}}{{ $commit }}{{end}} </p>{{end}}
         {{if .Metadata.RepositoryMetadata.Subfolder}}<p><b>Subfolder:</b> {{ .Metadata.RepositoryMetadata.Subfolder }} </p>{{end}}
       </div> 
-    </div>
+      <button
+      class="theme-switcher-grid"
+      id="theme-switcher-grid"
+      aria-label="Switch theme"
+    >
+      <div class="sun" id="sun" aria-hidden="true"></div>
+      <div class="moon-overlay" id="moon-overlay" aria-hidden="true"></div>
+      <div
+        class="cloud-ball cloud-ball-left"
+        id="ball1"
+        aria-hidden="true"
+      ></div>
+      <div
+        class="cloud-ball cloud-ball-middle"
+        id="ball2"
+        aria-hidden="true"
+      ></div>
+      <div
+        class="cloud-ball cloud-ball-right"
+        id="ball3"
+        aria-hidden="true"
+      ></div>
+      <div
+        class="cloud-ball cloud-ball-top"
+        id="ball4"
+        aria-hidden="true"
+      ></div>
+      <div class="star" id="star1" aria-hidden="true"></div>
+      <div class="star" id="star2" aria-hidden="true"></div>
+      <div class="star" id="star3" aria-hidden="true"></div>
+      <div class="star" id="star4" aria-hidden="true"></div>
+    </button>
+  </div>
+    
   </header>
 
   <div class="main-container">
@@ -290,7 +482,7 @@
           </div>
           <div class="issue-card__body">
             <div class="issue-card__body__metadata severity--{{$level}}">
-              <p>{{index .Properties "Description"}}</p>
+              {{index .Properties "Description"}}<br><br>
               {{ $location := index .Locations 0}}
               {{ $locationURI := index $location.PhysicalLocation.ArtifactLocation.Properties "URI"}}
               {{ $locationStartLine := $location.PhysicalLocation.Region.StartLine }}
@@ -378,6 +570,64 @@
   </div>
 
   <script>
+    function setTheme(mode) {
+      const themeSwitcher = document.getElementById("theme-switcher-grid");
+
+      if (mode === "dark") {
+        document.body.classList.add("dark-mode");
+        themeSwitcher.classList.add("night-theme");
+      } else {
+        document.body.classList.remove("dark-mode");
+        themeSwitcher.classList.remove("night-theme");
+      }
+    }
+
+    function getSystemThemePreference() {
+      return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? "dark" : "light";
+    }
+
+    function getSavedTheme() {
+      return localStorage.getItem("theme");
+    }
+
+    function saveThemePreference(mode) {
+      localStorage.setItem("theme", mode);
+    }
+
+    function initializeTheme() {
+      const savedTheme = getSavedTheme();
+      const systemTheme = getSystemThemePreference();
+
+      if (savedTheme) {
+        setTheme(savedTheme);
+      } else {
+        setTheme(systemTheme);
+      }
+    }
+
+    document.getElementById("theme-switcher-grid").addEventListener("click", function () {
+      const isDarkMode = document.body.classList.contains("dark-mode");
+
+      if (isDarkMode) {
+        setTheme("light");
+        saveThemePreference("light");
+      } else {
+        setTheme("dark");
+        saveThemePreference("dark");
+      }
+    });
+
+    initializeTheme();
+
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', e => {
+      const newSystemTheme = e.matches ? "dark" : "light";
+      const savedTheme = getSavedTheme();
+
+      if (!savedTheme) {
+        setTheme(newSystemTheme);
+      }
+    });
+
     var s = null;
 
     function updateSelectedDataflow(event, dataflowId) {

--- a/templates/tohtml/report.html
+++ b/templates/tohtml/report.html
@@ -797,7 +797,6 @@
       });
 
       // Dataflow update logic (if necessary, based on your previous requirements)
-      var s = null;
       function updateSelectedDataflow(event, dataflowId) {
         const selectedElement = event.target.closest('header').querySelector('.selected-dataflow-id');
         if (selectedElement) {

--- a/templates/tohtml/report.html
+++ b/templates/tohtml/report.html
@@ -21,6 +21,36 @@
       --night-bg-color: #272a30;
       --cloud-color: #fffdf2;
       --star-color: #fffdf2;
+      --footer-bg-light: #f1f1f1;
+      --footer-bg-dark: #0d1117;
+      --footer-text-light: #1c2135;
+      --footer-text-dark: #f0f0e8;
+      --footer-border-light: #1c2135;
+      --footer-border-dark: #1c2135;
+      --footer-link-light: #0d1117;
+      --footer-link-dark: #f1f1f1;;
+      --footer-link-hover-light: #0056b3;
+      --footer-link-hover-dark: #4a90e2;
+      --footer-heading-light: #007bff;
+      --footer-heading-dark: #31bc81;
+    }
+
+    body.light-mode {
+      --footer-bg: var(--footer-bg-light);
+      --footer-text: var(--footer-text-light);
+      --footer-border: var(--footer-border-light);
+      --footer-link: var(--footer-link-light);
+      --footer-link-hover: var(--footer-link-hover-light);
+      --footer-heading: var(--footer-heading-light);
+    }
+
+    body.dark-mode {
+      --footer-bg: var(--footer-bg-dark);
+      --footer-text: var(--footer-text-dark);
+      --footer-border: var(--footer-border-dark);
+      --footer-link: var(--footer-link-dark);
+      --footer-link-hover: var(--footer-link-hover-dark);
+      --footer-heading: var(--footer-heading-dark);
     }
 
     body {
@@ -44,20 +74,6 @@
       position: relative;
     }
 
-    /* .main-body-summary {
-      margin-bottom: 32px;
-    } */
-
-    .issue-card___header {
-      display: flex;
-      margin-bottom: 16px;
-    }
-
-    .issue-card__title {
-      font-size: 24px;
-      margin: 0px;
-    }
-
     .issue-card {
       left: 0;
       top: 10px;
@@ -68,6 +84,15 @@
       background-color: #F3F3F3;
     }
 
+    .issue-card___header {
+      display: flex;
+      margin-bottom: 16px;
+    }
+
+    .issue-card__title {
+      font-size: 24px;
+      margin: 0px;
+    }
 
     body.dark-mode .issue-card {
       background-color: #151b23f2;
@@ -246,7 +271,6 @@
     .header-container__logo {
       width: 64px;
       height: 64px;
-      /* margin: 0 16px; */
     }
 
     .header-container-centering {
@@ -259,7 +283,6 @@
     }
 
     .header-container__issues-breakdown {
-      /* margin: auto; */
       font-size: 14px;
       background-color: rgba(0, 0, 0, 0.05);
       padding: 12px;
@@ -292,7 +315,7 @@
       appearance: none;
     }
 
-    .theme-switcher-grid.night-theme {
+    .theme-switcher-grid.dark-mode {
       background-color: var(--night-bg-color);
       border-color: var(--border-color-dark);
     }
@@ -306,7 +329,7 @@
       height: 20px;
     }
 
-    .theme-switcher-grid.night-theme .sun {
+    .theme-switcher-grid.dark-mode .sun {
       grid-column: 33 / 53;
       background-color: var(--moon-color);
     }
@@ -319,7 +342,7 @@
       background-color: var(--day-bg-color);
     }
 
-    .theme-switcher-grid.night-theme .moon-overlay {
+    .theme-switcher-grid.dark-mode .moon-overlay {
       display: block;
       left: calc(28 / 54 * 100%);
       top: calc(4 / 29 * 100%);
@@ -343,10 +366,10 @@
     #ball3 { top: calc((8 / 24) * 100%); left: calc((22 / 54) * 100%); }
     #ball4 { top: calc((6 / 24) * 100%); left: calc((17 / 54) * 100%); }
 
-    .theme-switcher-grid.night-theme #ball1 { top: calc((17 / 24) * 100%); left: calc((17 / 54) * 100%); width: 2px; height: 2px; }
-    .theme-switcher-grid.night-theme #ball2 { top: calc((4 / 24) * 100%); left: calc((23 / 54) * 100%); width: 2px; height: 2px; }
-    .theme-switcher-grid.night-theme #ball3 { top: calc((11 / 24) * 100%); left: calc((30 / 54) * 100%); width: 2px; height: 2px; }
-    .theme-switcher-grid.night-theme #ball4 { top: calc((6 / 24) * 100%); left: calc((35 / 54) * 100%); width: 2px; height: 2px; }
+    .theme-switcher-grid.dark-mode #ball1 { top: calc((17 / 24) * 100%); left: calc((17 / 54) * 100%); width: 2px; height: 2px; }
+    .theme-switcher-grid.dark-mode #ball2 { top: calc((4 / 24) * 100%); left: calc((23 / 54) * 100%); width: 2px; height: 2px; }
+    .theme-switcher-grid.dark-mode #ball3 { top: calc((11 / 24) * 100%); left: calc((30 / 54) * 100%); width: 2px; height: 2px; }
+    .theme-switcher-grid.dark-mode #ball4 { top: calc((6 / 24) * 100%); left: calc((35 / 54) * 100%); width: 2px; height: 2px; }
 
     .star { 
       background-color: var(--star-color); 
@@ -361,10 +384,10 @@
     #star3 { top: calc((11 / 24) * 100%); left: calc((17 / 54) * 100%); }
     #star4 { top: calc((18 / 24) * 100%); left: calc((25 / 54) * 100%); }
 
-    .theme-switcher-grid.night-theme #star1,
-    .theme-switcher-grid.night-theme #star2,
-    .theme-switcher-grid.night-theme #star3,
-    .theme-switcher-grid.night-theme #star4 {
+    .theme-switcher-grid.dark-mode #star1,
+    .theme-switcher-grid.dark-mode #star2,
+    .theme-switcher-grid.dark-mode #star3,
+    .theme-switcher-grid.dark-mode #star4 {
       opacity: 1;
     }
 
@@ -378,6 +401,76 @@
       cursor: pointer;
     }
 
+    .fancy-footer {
+      background-color: var(--footer-bg);
+      color: var(--footer-text);
+      padding: 10px 10px;
+      text-align: left;
+      font-family: 'Open Sans', system-ui, Helvetica, sans-serif;
+      border-top: 1px solid var(--footer-border);
+    }
+
+    .footer-container {
+      display: flex;
+      justify-content: space-around;
+      max-width: 1024px;
+      margin: 0 auto;
+      padding-bottom: 10px;
+      border-bottom: 1px solid var(--footer-border);
+    }
+
+    .footer-section {
+      flex: 1;
+      min-width: 200px;
+    }
+
+    .footer-section h4 {
+      color: var(--footer-heading);
+      font-size: 16px;
+      margin-bottom: 10px;
+      transition: color 0.5s ease-in-out;
+    }
+
+    .footer-section ul {
+      list-style: none;
+      padding: 0;
+    }
+
+    .footer-section ul li {
+      margin-bottom: 10px;
+      font-size: 16px;
+      transition: color 0.5s ease-in-out;
+    }
+
+    .footer-section ul li a {
+      color: var(--footer-link);
+      text-decoration: none;
+      transition: color 0.5s ease-in-out;
+    }
+
+    .footer-section ul li a:hover {
+      color: var(--footer-link-hover);
+    }
+
+    .footer-bottom {
+      text-align: center;
+      padding-top: 10px;
+      color: #8a939f;
+    }
+
+    .footer-bottom a {
+      color: var(--footer-link);
+      text-decoration: none;
+    }
+
+    .footer-bottom a:hover {
+      text-decoration: underline;
+    }
+
+    .footer-bottom p {
+      font-size: 14px;
+      margin: 0;
+    }
   </style>
 
 </head>
@@ -575,10 +668,12 @@
 
       if (mode === "dark") {
         document.body.classList.add("dark-mode");
-        themeSwitcher.classList.add("night-theme");
+        themeSwitcher.classList.add("dark-mode");
+        document.body.classList.remove("light-mode");
       } else {
+        document.body.classList.add("light-mode");
         document.body.classList.remove("dark-mode");
-        themeSwitcher.classList.remove("night-theme");
+        themeSwitcher.classList.remove("dark-mode");
       }
     }
 
@@ -652,3 +747,28 @@
     }
   </script>
 </body>
+<footer class="fancy-footer">
+  <div class="footer-container">
+    <div class="footer-section">
+      <h4>Resources</h4>
+      <ul>
+        <li><a href="https://github.com/scan-io-git/scan-io">Scanio GitHub</a></li>
+        <!-- <li><a href="#">Documentation</a></li> -->
+        <!-- <li><a href="#">Support</a></li> -->
+      </ul>
+    </div>
+
+    <div class="footer-section">
+      <h4>About</h4>
+      <ul>
+        <li>Scanio Orchestrator version 0.2.0</li>
+        <!-- <li><a href="#">Contact</a></li> -->
+      </ul>
+    </div>
+  </div>
+
+  <div class="footer-bottom">
+    <p>&copy; 2024 Scanio Orchestrator</p>
+    <!-- <p><a href="#">Privacy Policy</a> | <a href="#">Terms of Service</a></p> -->
+  </div>
+</footer>

--- a/templates/tohtml/report.html
+++ b/templates/tohtml/report.html
@@ -267,7 +267,7 @@
         {{if .Metadata.SourceFolder}}<p><b>Source:</b> {{ .Metadata.SourceFolder }}</p>{{end}}
         {{if $repo}}<p><b>Repository:</b> <a href="{{ $webURL }}">{{ $repo }}</a></p>{{end}}
         {{if $branch}}<p><b>Branch:</b> {{if $branchURL}}<a href="{{- $branchURL -}}">{{ $branch }}</a>{{else}}{{ $branch }}{{end}} </p>{{end}}
-        {{if $commit}}<p><b>Commit:</b> {{if $commitURL}}<a href="{{- $commitURL -}}">{{ $commit }}</a>{{else}}{{ $commit }}{{end}} </p>{{end}}
+        {{if $commit}}<p><b>Latest Commit:</b> {{if $commitURL}}<a href="{{- $commitURL -}}">{{ $commit }}</a>{{else}}{{ $commit }}{{end}} </p>{{end}}
         {{if .Metadata.RepositoryMetadata.Subfolder}}<p><b>Subfolder:</b> {{ .Metadata.RepositoryMetadata.Subfolder }} </p>{{end}}
       </div> 
     </div>

--- a/templates/tohtml/report.html
+++ b/templates/tohtml/report.html
@@ -11,46 +11,37 @@
 
   <style type="text/css">
     :root {
-      --bg-color-light: #dad7cd;
+      --bg-color-light: #ffffff;
       --bg-color-dark: #0d1117;
+      --text-color-light: #1c2135;
+      --text-color-dark: #f0f0e8;
       --border-color-light: #1c2135;
       --border-color-dark: #f0f0e8;
+      --primary-color-light: #007bff;
+      --primary-color-dark: #31bc81;
+      --issue-card-border-color-light: #d3d3d9;
+      --issue-card-border-color-dark: #8a939f;
+      --issue-card-bg-color-light: #f3f3f3;
+      --issue-card-bg-color-dark: #151b23f2;
+    
+      --footer-bg-light: #f1f1f1;
+      --footer-bg-dark: #0d1117;
+      --footer-text-light: #1c2135;
+      --footer-text-dark: #f0f0e8;
+      --footer-link-light: #0d1117;
+      --footer-link-dark: #f1f1f1;
+      --footer-link-hover-light: #0056b3;
+      --footer-link-hover-dark: #4a90e2;
+      --footer-heading-light: #007bff;
+      --footer-heading-dark: #31bc81;
+      --footer-border-light: #8a939f;
+
       --sun-color: #fabc1c;
       --moon-color: #fffdf2;
       --day-bg-color: #0dbdf6;
       --night-bg-color: #272a30;
       --cloud-color: #fffdf2;
       --star-color: #fffdf2;
-      --footer-bg-light: #f1f1f1;
-      --footer-bg-dark: #0d1117;
-      --footer-text-light: #1c2135;
-      --footer-text-dark: #f0f0e8;
-      --footer-border-light: #1c2135;
-      --footer-border-dark: #1c2135;
-      --footer-link-light: #0d1117;
-      --footer-link-dark: #f1f1f1;;
-      --footer-link-hover-light: #0056b3;
-      --footer-link-hover-dark: #4a90e2;
-      --footer-heading-light: #007bff;
-      --footer-heading-dark: #31bc81;
-    }
-
-    body.light-mode {
-      --footer-bg: var(--footer-bg-light);
-      --footer-text: var(--footer-text-light);
-      --footer-border: var(--footer-border-light);
-      --footer-link: var(--footer-link-light);
-      --footer-link-hover: var(--footer-link-hover-light);
-      --footer-heading: var(--footer-heading-light);
-    }
-
-    body.dark-mode {
-      --footer-bg: var(--footer-bg-dark);
-      --footer-text: var(--footer-text-dark);
-      --footer-border: var(--footer-border-dark);
-      --footer-link: var(--footer-link-dark);
-      --footer-link-hover: var(--footer-link-hover-dark);
-      --footer-heading: var(--footer-heading-dark);
     }
 
     body {
@@ -60,11 +51,28 @@
       display: flex;
       flex-direction: column;
       transition: background-color 0.5s ease-in-out, color 0.5s ease-in-out;
+      background-color: var(--bg-color-light);
+      --text-color: var(--text-color-light);
+      --border-color: var(--border-color-light);
+      --footer-bg: var(--footer-bg-light);
+      --footer-border: var(--footer-border-light);
+      --footer-text: var(--footer-text-light);
+      --footer-link: var(--footer-link-light);
+      --footer-link-hover: var(--footer-link-hover-light);
+      --footer-heading: var(--footer-heading-light);
+      --primary-color: var(--primary-color-light);
     }
 
     body.dark-mode {
       background-color: var(--bg-color-dark);
-      color: #F1F1F1;
+      color: var(--text-color-dark);
+      --border-color: var(--border-color-dark);
+      --footer-bg: var(--footer-bg-dark);
+      --footer-text: var(--footer-text-dark);
+      --footer-link: var(--footer-link-dark);
+      --footer-link-hover: var(--footer-link-hover-dark);
+      --footer-heading: var(--footer-heading-dark);
+      --primary-color: var(--primary-color-dark);
     }
 
     .main-body {
@@ -81,7 +89,7 @@
       border-radius: 8px;
       border: 2px solid;
       margin-bottom: 40px;
-      background-color: #F3F3F3;
+      background-color: var(--issue-card-bg-color-light);
     }
 
     .issue-card___header {
@@ -95,8 +103,8 @@
     }
 
     body.dark-mode .issue-card {
-      background-color: #151b23f2;
-      border-color: #8a939f;
+      background-color: var(--issue-card-bg-color-dark);
+      border-color: var(--issue-card-border-color-dark);
     }
 
     .severity--error {
@@ -145,27 +153,24 @@
 
     .issue-card__body__metadata {
       padding: 8px 8px;
-      border: 2px solid #d3d3d9;
+      border: 2px solid var(--issue-card-border-color-light);
       border-radius: 8px;
       margin-bottom: 8px;
       overflow: auto;
     }
 
-    body.dark-mode .issue-card__body__metadata {
-      border-color: #8a939f;
+    body.dark-mode .issue-card__body__metadata,
+    body.dark-mode .issue-card__body__dataflows__filename,
+    body.dark-mode .issue-card__body__dataflow-id {
+      border-color: var(--issue-card-border-color-dark);
       background-color: var(--bg-color-dark);
     }
 
     .issue-card__body__dataflows__filename {
       padding:4px 8px;
-      border:1px solid #d3d3d9;
+      border:1px solid var(--issue-card-border-color-light);
       border-radius: 8px;
       font-size:14px;
-    }
-
-    body.dark-mode .issue-card__body__dataflows__filename {
-      border-color: #8a939f;
-      background-color: var(--bg-color-dark);
     }
 
     .issue-card__body__dataflows__codeline {
@@ -193,15 +198,11 @@
       display: inline-block;
       width: 16px; 
       height: 16px; 
-      border: 2px solid #d3d3d9; 
+      border: 2px solid var(--issue-card-border-color-light); 
       border-radius: 50%;
       text-align: center; 
       line-height: 1.5;
       font-size: 14px;
-    }
-
-    body.dark-mode .issue-card__body__dataflow-id {
-      background-color: #8a939f;
     }
 
     .card__body__dataflows__header {
@@ -213,7 +214,7 @@
     }
 
     .selected-dataflow-id {
-      background-color:#31bc81;
+      background-color:var(--primary-color-dark);
       color: #ffffff;
     }
 
@@ -237,7 +238,7 @@
     .header-container {
       justify-content: space-between;
       align-items: center;
-      background-color: #32bc81;
+      background-color: var(--primary-color-dark);
       color: #000;
       padding: 8px;
     }
@@ -334,7 +335,7 @@
       background-color: var(--moon-color);
     }
 
-    .moon-overlay {
+    .moon-overlay, .cloud-ball, .star {
       position: absolute;
       border-radius: 50%;
       transition: left 0.5s ease, background-color 0.5s ease;
@@ -445,7 +446,6 @@
     .footer-bottom {
       text-align: center;
       padding-top: 10px;
-      color: #8a939f;
     }
 
     .footer-bottom a {
@@ -487,15 +487,15 @@
     }
 
     body.light-mode .scroll-up-button svg {
-      color: #007bff; 
+      color: var(--primary-color-light); 
     }
 
     body.dark-mode .scroll-up-button svg {
-      color: #31bc81; 
+      color: var(--primary-color-dark); 
     }
 
     .scroll-up-button:hover {
-      transform: translateY(-3px);
+      transform: translateY(-5px);
     }
 
     .scroll-up-button:active {
@@ -505,14 +505,15 @@
     .scroll-up-button.show {
       visibility: visible; 
       opacity: 1; 
+      transform: translateY(0);
     }
 
     .scroll-up-button.hide {
       visibility: hidden; 
       opacity: 0; 
       pointer-events: none;
+      transform: translateY(10px);
     }
-
   </style>
 
 </head>
@@ -709,6 +710,24 @@
       const scrollUpButton = document.getElementById("scrollUpButton");
       const thresholdPercentage = 0.2; 
 
+      let debounceTimer;
+  
+      window.addEventListener("scroll", function () {
+        clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(handleScroll, 100); 
+      });
+
+      function handleScroll() {
+        const scrollHeight = document.documentElement.scrollHeight;
+        const scrollRatio = window.scrollY / scrollHeight;
+      
+        if (scrollRatio > thresholdPercentage) {
+          scrollUpButton.classList.add("show");
+        } else {
+          scrollUpButton.classList.remove("show");
+        }
+      }
+
       window.addEventListener("scroll", function () {
         const scrollHeight = document.documentElement.scrollHeight;
         const scrollRatio = window.scrollY / scrollHeight;
@@ -727,18 +746,14 @@
         });
       });
 
+      const body = document.body;
       const themeSwitcher = document.getElementById("theme-switcher-grid");
 
       function setTheme(mode) {
-        if (mode === "dark") {
-          document.body.classList.add("dark-mode");
-          document.body.classList.remove("light-mode");
-          themeSwitcher.classList.add("dark-mode");
-        } else {
-          document.body.classList.add("light-mode");
-          document.body.classList.remove("dark-mode");
-          themeSwitcher.classList.remove("dark-mode");
-        }
+        const isDarkMode = mode === "dark";
+        body.classList.toggle("dark-mode", isDarkMode);
+        body.classList.toggle("light-mode", !isDarkMode);
+        themeSwitcher.classList.toggle("dark-mode", isDarkMode);
       }
 
       function getSystemThemePreference() {
@@ -754,14 +769,8 @@
       }
 
       function initializeTheme() {
-        const savedTheme = getSavedTheme();
-        const systemTheme = getSystemThemePreference();
-
-        if (savedTheme) {
-          setTheme(savedTheme);
-        } else {
-          setTheme(systemTheme);
-        }
+        const savedTheme = getSavedTheme() || getSystemThemePreference();
+        setTheme(savedTheme);
       }
 
       themeSwitcher.addEventListener("click", function () {
@@ -790,8 +799,6 @@
       // Dataflow update logic (if necessary, based on your previous requirements)
       var s = null;
       function updateSelectedDataflow(event, dataflowId) {
-        console.log(event);
-        s = event;
         const selectedElement = event.target.closest('header').querySelector('.selected-dataflow-id');
         if (selectedElement) {
           selectedElement.classList.remove('selected-dataflow-id');
@@ -803,7 +810,7 @@
         if (currentDataflowElement) {
           currentDataflowElement.classList.remove('selected-dataflow');
         }
-        const selectedDataflowElement = dataflowContainer.querySelector('.issue-card__body__dataflow--' + dataflowId);
+        const selectedDataflowElement = dataflowContainer.querySelector(`.issue-card__body__dataflow--${dataflowId}`);
         if (selectedDataflowElement) {
           selectedDataflowElement.classList.add('selected-dataflow');
         }


### PR DESCRIPTION
**Warning**: This update touches on a potentially controversial design topic!

After spending a bunch of hours reviewing reports in the light theme, I realized I needed something that worked better in dark mode. The purple tones were toxic and overwhelming in a dark theme, so I opted for a softer, less aggressive palette.

Updates list:
- Introduced a new color scheme for the HTML report template.
- Added full support for dark mode.
- Enhanced readability, layout, and overall style.
- Added a footer with dark mode support.
- Added scroll up button.

New color palette: 
![new_tm_light](https://github.com/user-attachments/assets/3de49747-c119-4957-94b9-164b1fa5012f)
![new_tm_dark](https://github.com/user-attachments/assets/8eae5d6b-72df-4dcd-ac74-f61099915078)

Old color palette:
![old_tm_light](https://github.com/user-attachments/assets/cee4efff-008b-46c9-9606-502350115f39)
