### PR TITLE
feat(findings): add minimal internal finding model

### DIFF
--- a/internal/findings/finding.go
+++ b/internal/findings/finding.go
@@ -1,0 +1,41 @@
+package findings
+
+// Property is a simple name/value pair used for tags, references, or custom metadata.
+type Property struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// CodeFlowStep represents a single step in a data flow.
+type CodeFlowStep struct {
+	FilePath    string `json:"file_path"`
+	StartLine   int    `json:"start_line"`
+	StartColumn int    `json:"start_column"`
+	EndLine     int    `json:"end_line"`
+	EndColumn   int    `json:"end_column"`
+	Message     string `json:"message,omitempty"`
+}
+
+// CodeFlow contains a sequence of steps describing a flow.
+type CodeFlow struct {
+	Steps []CodeFlowStep `json:"steps"`
+}
+
+// Finding is a minimal internal domain model extracted from SARIF or other scanners.
+type Finding struct {
+	RuleID      string `json:"rule_id"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	Severity    string `json:"severity"`
+	Scanner     string `json:"scanner"`
+
+	FilePath  string `json:"file_path"`
+	StartLine int    `json:"start_line"`
+	EndLine   int    `json:"end_line"`
+
+	Tags       []Property `json:"tags,omitempty"`
+	References []Property `json:"references,omitempty"`
+	Properties []Property `json:"properties,omitempty"`
+
+	CodeFlows []CodeFlow `json:"code_flows,omitempty"`
+}


### PR DESCRIPTION
This is the first phase of proposed plan for sarif and findings refactoring.

`internal/findings/finding.go` defines the minimal Finding domain model (can be extended later if needed).

There are AI generated examples of using this model for different types of scanners:
```go
[
  {
    "rule_id": "sql-injection",
    "title": "Potential SQL injection",
    "description": "User-controlled input flows into SQL query without parameterization.",
    "severity": "High",
    "scanner": "Semgrep",
    "file_path": "src/db/user.go",
    "start_line": 42,
    "end_line": 45,
    "tags": [{"name": "CWE", "value": "CWE-89"}],
    "references": [{"name": "OWASP", "value": "https://owasp.org/www-community/attacks/SQL_Injection"}],
    "code_flows": [
      {"steps": [
        {"file_path": "src/handlers/user.go", "start_line": 18, "end_line": 18, "start_column": 15, "end_column": 33, "message": "user input"},
        {"file_path": "src/db/user.go", "start_line": 42, "end_line": 42, "start_column": 12, "end_column": 46, "message": "query construction"}
      ]}
    ]
  },
  {
    "rule_id": "CVE-2023-12345",
    "title": "Vulnerable dependency: github.com/acme/lib",
    "description": "Library version 1.2.3 is affected by a known RCE.",
    "severity": "High",
    "scanner": "Snyk",
    "file_path": "go.mod",
    "start_line": 12,
    "end_line": 12,
    "tags": [{"name": "CVE", "value": "CVE-2023-12345"}],
    "references": [{"name": "NVD", "value": "https://nvd.nist.gov/vuln/detail/CVE-2023-12345"}],
    "properties": [{"name": "package", "value": "github.com/acme/lib@1.2.3"}]
  },
  {
    "rule_id": "S3_BUCKET_PUBLIC_READ",
    "title": "S3 bucket allows public read",
    "description": "Bucket ACL allows public read access.",
    "severity": "Medium",
    "scanner": "Checkov",
    "file_path": "infra/s3.tf",
    "start_line": 7,
    "end_line": 14,
    "tags": [{"name": "CIS", "value": "CIS-1.1.0"}],
    "references": [{"name": "AWS", "value": "https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-control-block-public-access.html"}]
  },
  {
    "rule_id": "AWS_ACCESS_KEY",
    "title": "Hardcoded AWS access key",
    "description": "Possible AWS access key detected.",
    "severity": "High",
    "scanner": "TruffleHog",
    "file_path": "config/dev.env",
    "start_line": 3,
    "end_line": 3,
    "tags": [{"name": "Secret", "value": "AWS Access Key"}]
  },
  {
    "rule_id": "CVE-2022-9999",
    "title": "Base image contains vulnerable OpenSSL",
    "description": "Image layer includes OpenSSL vulnerable to CVE-2022-9999.",
    "severity": "High",
    "scanner": "Trivy",
    "file_path": "Dockerfile",
    "start_line": 1,
    "end_line": 1,
    "tags": [{"name": "CVE", "value": "CVE-2022-9999"}],
    "properties": [{"name": "image", "value": "alpine:3.14"}]
  },
  {
    "rule_id": "XSS-REFLECTED",
    "title": "Reflected XSS in search endpoint",
    "description": "Unescaped query parameter is reflected in HTML response.",
    "severity": "Medium",
    "scanner": "OWASP ZAP",
    "file_path": "https://app.example.com/search",
    "start_line": 0,
    "end_line": 0,
    "properties": [{"name": "http_method", "value": "GET"}, {"name": "param", "value": "q"}]
  },
  {
    "rule_id": "API_AUTHZ_MISSING",
    "title": "Missing authorization on admin endpoint",
    "description": "Admin endpoint lacks authorization checks.",
    "severity": "High",
    "scanner": "42Crunch",
    "file_path": "openapi.yaml",
    "start_line": 128,
    "end_line": 145,
    "tags": [{"name": "OWASP", "value": "API4:2019 - Lack of Resources & Rate Limiting"}]
  }
]
```