### PR TITLE
fix: bump images, run as non-root, recover from diff panics on oversized files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 ARG PLUGINS="github,gitlab,bitbucket,semgrep,bandit,trufflehog"
 
 # Stage 1: Build Scanio core and plugins
-FROM golang:1.25.1-alpine3.21 AS build-scanio
+FROM golang:1.25.9-alpine3.23 AS build-scanio
 
 WORKDIR /usr/src/scanio
 
@@ -35,7 +35,7 @@ RUN echo "Building binaries and plugins for '$TARGETOS/$TARGETARCH'"
 RUN make build PLUGINS="$PLUGINS" CORE_BINARY=/usr/bin/scanio PLUGINS_DIR=/usr/bin/plugins
 
 # Stage 2: Prepare the runtime environment
-FROM alpine:3.21.3 AS runtime
+FROM alpine:3.23.4 AS runtime
 
 # Set target architecture for multi-arch builds
 ARG TARGETOS
@@ -64,7 +64,7 @@ RUN set -euxo pipefail && \
           echo "Installing Semgrep..."; \
           python3 -m venv "$PLUGIN_VENVS_DIR/semgrep" && \
           . "$PLUGIN_VENVS_DIR/semgrep/bin/activate" && \
-          pip install --no-cache-dir semgrep==1.120.1 ;; \
+          pip install --no-cache-dir semgrep==1.161.0 ;; \
         trufflehog3) \
           echo "Installing Trufflehog3..."; \
           apk add --no-cache git; \
@@ -75,10 +75,10 @@ RUN set -euxo pipefail && \
           echo "Installing Bandit..."; \
           python3 -m venv "$PLUGIN_VENVS_DIR/bandit" && \
           . "$PLUGIN_VENVS_DIR/bandit/bin/activate" && \
-          pip install --no-cache-dir bandit==1.8.3 ;; \
+          pip install --no-cache-dir bandit==1.9.4 ;; \
         trufflehog) \
           echo "Installing TruffleHog binary..."; \
-          TRUFFLEHOG_VER="3.88.27" && \
+          TRUFFLEHOG_VER="3.95.2" && \
           TARFILE="trufflehog_${TRUFFLEHOG_VER}_${TARGETOS}_${TARGETARCH}.tar.gz" && \
           CHECKSUMFILE="trufflehog_${TRUFFLEHOG_VER}_checksums.txt" && \
           curl -LOs "https://github.com/trufflesecurity/trufflehog/releases/download/v${TRUFFLEHOG_VER}/${CHECKSUMFILE}" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -122,5 +122,10 @@ RUN echo -e "\n\nscanio:" >> /scanio/config.yml && \
     echo -e "  temp_folder: /scanio/tmp" >> /scanio/config.yml && \
     echo -e "  artifacts_folder: /scanio/artifacts\n" >> /scanio/config.yml
 
+RUN addgroup -S scanio && adduser -S -G scanio scanio && \
+    chown -R scanio:scanio /scanio /data
+
+USER scanio
+
 ENTRYPOINT ["/bin/scanio"]
 CMD ["--help"]

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/sourcegraph/go-diff/diff"
 
 	sharedfiles "github.com/scan-io-git/scan-io/pkg/shared/files"
@@ -65,12 +66,22 @@ func AddedLines(gitClient *Client, repoPath, baseHash, headHash string, filters 
 		return nil, fmt.Errorf("failed to load head tree: %w", err)
 	}
 
-	patch, err := baseTree.Patch(headTree)
+	changes, err := baseTree.Diff(headTree)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compute diff: %w", err)
 	}
 
-	parsed, err := diff.ParseMultiFileDiff([]byte(patch.String()))
+	var patchBuf bytes.Buffer
+	for _, c := range changes {
+		p, pErr := safePatch(c)
+		if pErr != nil {
+			gitClient.logger.Warn("skipping file in diff (too large for in-memory diff)", "err", pErr)
+			continue
+		}
+		patchBuf.WriteString(p.String())
+	}
+
+	parsed, err := diff.ParseMultiFileDiff(patchBuf.Bytes())
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse diff: %w", err)
 	}
@@ -213,6 +224,19 @@ func writeSparseFile(repoRoot, diffRoot, relPath string, lines map[int]string) e
 	}
 
 	return nil
+}
+
+// safePatch computes the patch for a single file change, recovering from panics
+// that sergi/go-diff can produce when a file has more unique lines than Unicode
+// rune space (~1.1M). On panic the error is returned and the caller skips the file.
+func safePatch(c *object.Change) (p *object.Patch, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("diff panic: %v", r)
+		}
+	}()
+	p, err = c.Patch()
+	return
 }
 
 // buildFilterSet returns an O(1) lookup table for the provided filter slice.


### PR DESCRIPTION
## What
Bump Docker base images and plugin versions to address CVEs, run the container as a non-root user, and recover gracefully from panics in the git diff logic for oversized files.

## Why
Outdated base images and plugin versions contain known CVEs. Running as root in containers is a security risk. The sergi/go-diff library panics when a file has more unique lines than the Unicode rune space (~1.1M), causing the entire diff operation to crash instead of skipping the problematic file.

## Changes

- Dockerfile: bump Go builder from golang:1.25.1-alpine3.21 to golang:1.25.9-alpine3.23
- Dockerfile: bump runtime base from alpine:3.21.3 to alpine:3.23.4
- Dockerfile: upgrade plugin versions: Semgrep 1.120.1 -> 1.161.0, Bandit 1.8.3 -> 1.9.4, TruffleHog 3.88.27 -> 3.95.2
- Dockerfile: add scanio user/group, chown /scanio and /data, switch to USER scanio so the container runs as non-root
- internal/git/diff.go: replace single baseTree.Patch(headTree) call with per-file iteration using baseTree.Diff(), wrapping each c.Patch() in a safePatch helper that recovers from panics and logs a warning, allowing oversized files to be skipped rather than crashing