### PR TITLE
fix(semgrep): create .cache for rosetta macos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -146,7 +146,7 @@ RUN echo -e "\n\nscanio:" >> /$APP_NAME/config.yml && \
 ENV SCANIO_CONFIG_PATH=/$APP_NAME/config.yml
 
 RUN addgroup -S $APP_NAME && adduser -S -G $APP_NAME -h /home/$APP_NAME $APP_NAME && \
-    mkdir -p /home/$APP_NAME && \
+    mkdir -p /home/$APP_NAME/.cache && \
     chown -R $APP_NAME:$APP_NAME /$APP_NAME /data /home/$APP_NAME
 
 # The non-root runtime user needs HOME set so tools that write to ~ (config,


### PR DESCRIPTION
On macOS using Rosetta emulation for amd64 platforms, this "fails" in the last step. semgrep/app/version.py's _get_version_info() function tries to create a file inside of ~/.cache. This causes a terminating error in semgrep, and scan-io reports a failure.

It fails because on Rosetta, macOS creates the ~/.cache folder owned by root regardless of the actual running user. The permissions are too strict to create any files inside of it. If the folder is created first, then the permissions are fine.

The proper fix would be to advise people to use multiplatform images, for Docker to fix this issue on macOS, or for semgrep to not have a terminating error when unable to create files inside of ~/.cache. This is a workaround.

See-also: docker/for-mac#7440